### PR TITLE
feat: add rootless Podman role with Molecule tests

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,0 @@
-../../ai-agent-workspace/.claude/skills

--- a/.claude/skills/commit
+++ b/.claude/skills/commit
@@ -1,0 +1,1 @@
+../../../ai-agent-workspace/.claude/skills/commit

--- a/.claude/skills/create-memory-bank
+++ b/.claude/skills/create-memory-bank
@@ -1,0 +1,1 @@
+../../../ai-agent-workspace/.claude/skills/create-memory-bank

--- a/.claude/skills/format-markdown
+++ b/.claude/skills/format-markdown
@@ -1,0 +1,1 @@
+../../../ai-agent-workspace/.claude/skills/format-markdown

--- a/.claude/skills/sdd-extend
+++ b/.claude/skills/sdd-extend
@@ -1,0 +1,1 @@
+../../../ai-agent-workspace/.claude/skills/sdd-extend

--- a/.claude/skills/sdd-workflow
+++ b/.claude/skills/sdd-workflow
@@ -1,0 +1,1 @@
+../../../ai-agent-workspace/.claude/skills/sdd-workflow

--- a/.claude/skills/technical-coach/SKILL.md
+++ b/.claude/skills/technical-coach/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: technical-coach
+description: >
+  Use when expert knowledge of Ansible is required to advise and tutor on automating setup and maintenance of virtual machines.
+---
+Act as an experienced technical coach / technical consultant with expert knowledge using Ansible to automate setup and maintenance of virtual machines.
+
+Your goal is to advise me and **be my tutor** for related questions.
+
+Use the Context7 library /ansible/ansible-documentation for documentation and programming guidelines.
+
+Then ask me about **my current goal**.
+
+## Constraints
+
+- **Never write code or execute commands yourself.** Instead, tell me what needs to be done and guide me through the process.
+
+- Whenever you ask me questions, **ask questions one by one**, so that I can focus at the individual problem at hand.

--- a/.claude/skills/update-memory-bank
+++ b/.claude/skills/update-memory-bank
@@ -1,0 +1,1 @@
+../../../ai-agent-workspace/.claude/skills/update-memory-bank

--- a/.cursor/rules/340-molecule-testing.mdc
+++ b/.cursor/rules/340-molecule-testing.mdc
@@ -1,0 +1,134 @@
+---
+alwaysApply: false
+description: >
+  Use when implementing or modifying an Ansible role to set up or maintain
+  its Molecule test scenario.
+---
+
+# Molecule testing for Ansible roles
+
+See constitution Principle II for applicability. Roles requiring a full VM
+(desktop, display managers, hardware drivers) use `CONTRIBUTING.md` instead.
+
+## meta/main.yml — required fields
+
+```yaml
+galaxy_info:
+  namespace: wonderbird
+  role_name: <role-name>
+```
+
+## Required scenario files
+
+| File | Purpose |
+| --- | --- |
+| `molecule.yml` | Driver, platform, provisioner, verifier, test sequence |
+| `prepare.yml` | Bootstrap the container before converge |
+| `converge.yml` | Apply the role under test |
+| `verify.yml` | Assert observable outcomes |
+
+## molecule.yml
+
+```yaml
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: docker.io/library/ubuntu:24.04
+    pre_build_image: true
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy
+```
+
+## prepare.yml
+
+Bootstrap rules:
+
+- Two **separate** `raw` tasks — do NOT chain with `&&` in a folded scalar
+- Both MUST have `become: false` (sudo not yet installed)
+- Further tasks after bootstrap may inherit play-level `become: true`
+
+```yaml
+- name: Prepare container
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.raw: apt-get update
+      become: false
+      changed_when: true
+
+    - name: Install python3 and sudo
+      ansible.builtin.raw: apt-get install -y python3 sudo
+      become: false
+      changed_when: true
+```
+
+## converge.yml
+
+```yaml
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    my_var: value
+  roles:
+    - role: <role-name>
+```
+
+## verify.yml
+
+Use `ansible_facts['env']` — NOT `ansible_env` (deprecated, removed in 2.24).
+
+```yaml
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    - name: Check outcome
+      ansible.builtin.command: <command>
+      register: result
+      changed_when: false
+
+    - name: Assert outcome
+      ansible.builtin.assert:
+        that:
+          - "'expected' in result.stdout"
+```
+
+## Idempotence pitfalls
+
+- **Temporary files**: do not delete a downloaded file unconditionally; use a
+  `when:` guard or omit the cleanup task
+- **shell/command**: always add `creates:` or `changed_when:`
+
+## Running the tests
+
+```shell
+cd roles/<role-name>
+molecule test
+```
+
+All phases MUST pass before committing. The two podman schema warnings are
+expected and acceptable.
+
+## Happiness
+
+🧪

--- a/.cursor/rules/general/380-remediation-protocol.mdc
+++ b/.cursor/rules/general/380-remediation-protocol.mdc
@@ -1,0 +1,1 @@
+../../../../ai-agent-workspace/.cursor/rules/general/380-remediation-protocol.mdc

--- a/.cursor/rules/general/700-quality-of-agent-guidelines.mdc
+++ b/.cursor/rules/general/700-quality-of-agent-guidelines.mdc
@@ -1,0 +1,1 @@
+../../../../ai-agent-workspace/.cursor/rules/general/700-quality-of-agent-guidelines.mdc

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -21,19 +21,40 @@ most important property of reliable Ansible code.
 Every reusable capability MUST be implemented as a standalone Ansible role
 inside the `roles/` directory. Playbooks MUST only orchestrate roles; they
 MUST NOT contain implementation logic (tasks, handlers, templates) directly.
-Roles MUST have a clear single responsibility and MUST be independently
-testable on a local Vagrant/Tart VM.
+Roles MUST have a clear single responsibility.
+
+Every role that can be exercised in a container MUST include a Molecule test
+scenario in `molecule/default/`. The scenario MUST cover at minimum:
+
+- A `prepare.yml` that bootstraps the container to a state where Ansible can
+  operate (Python, sudo, and any required system users).
+- A `converge.yml` that applies the role under test.
+- A `verify.yml` that asserts the role's observable outcomes using
+  `ansible.builtin.assert`.
+- An explicit `test_sequence` in `molecule.yml` listing only the phases the
+  scenario defines.
+
+Roles that cannot be exercised in a container (e.g., desktop environment
+configuration, display managers, hardware drivers) MUST instead be validated
+on a local Vagrant/Tart VM as described in `CONTRIBUTING.md`.
 
 **Rationale**: Roles keep the codebase modular and reusable across different
-target hosts without duplicating logic.
+target hosts without duplicating logic. Molecule container tests provide fast,
+repeatable, local validation without requiring a full VM.
 
 ### III. Test Locally Before Cloud
 
-Changes to roles or playbooks MUST be validated on a local VM (Vagrant +
-Tart or Docker) before being applied to cloud-hosted machines (AWS EC2 or
-Hetzner). The test procedure defined in `CONTRIBUTING.md` MUST be followed:
-isolated role testing with the role under test as the only active role in
-`configure-linux-roles.yml`.
+Changes to roles or playbooks MUST be validated locally before being applied
+to cloud-hosted machines (AWS EC2 or Hetzner).
+
+For roles with a Molecule scenario, run `molecule test` from the role directory
+as the primary validation step. This covers the full create → prepare →
+converge → idempotence → verify → destroy lifecycle.
+
+For roles without a Molecule scenario (those requiring a full VM), follow the
+Vagrant-based procedure in `CONTRIBUTING.md`: isolate the role under test as
+the only active role in `configure-linux-roles.yml` and run the playbook
+against a local VM.
 
 **Rationale**: Local validation is fast, free and reversible. Cloud
 provisioning is slow and costs money; catching defects early avoids wasted
@@ -116,12 +137,15 @@ introduces uncontrolled changes and makes root-cause analysis impossible.
 ## Technology Stack
 
 - **Automation**: Ansible (playbooks, roles, inventory)
+- **Role testing**: Molecule (molecule>=24.0.0 + molecule-plugins[podman])
+  with the Podman driver for containerized role validation
 - **Local test VMs**: Vagrant + Tart (macOS ARM64), Vagrant + Docker (Linux)
+  for roles that cannot be containerized
 - **Cloud targets**: AWS EC2 (Linux + Windows Server 2025), Hetzner Cloud (Linux)
 - **Guest OS**: Ubuntu Linux (primary), Windows Server 2025 (secondary)
 - **Configuration**: `ansible.cfg`, `group_vars`, `host_vars`, `inventories/`
 - **Dependencies**: `requirements.yml` (Ansible Galaxy roles/collections),
-  `requirements.txt` (Python packages)
+  `requirements.txt` (Python packages including Molecule)
 - **Scripting**: Bash (`configure.sh`, `scripts/`)
 
 No additional runtime languages (Python services, Node apps, etc.) are
@@ -163,8 +187,8 @@ All documentation MUST comply with Principle VI (Markdown Quality Standards).
    ask clarifying questions before starting work. Resolve ambiguity one
    question at a time.
 2. **Feature branch**: create a branch named `###-short-description` from `main`.
-3. **Local test**: follow `CONTRIBUTING.md` — isolate the new/changed role and
-   run the playbook against a local VM.
+3. **Local test**: for roles with a Molecule scenario, run `molecule test` from
+   the role directory. For roles without one, follow `CONTRIBUTING.md`.
 4. **Commit**: use conventional commit format (Principle V); keep commits small
    and coherent.
 5. **User review**: after every commit, request a user review and wait for
@@ -197,4 +221,4 @@ All agents working in this repository MUST read this constitution at the start
 of any non-trivial task and verify that their plan complies with each principle.
 Runtime guidance for AI agents is in `CLAUDE.md` and `.cursor/rules/`.
 
-**Version**: 1.1.1 | **Ratified**: 2026-03-11 | **Last Amended**: 2026-03-26
+**Version**: 1.2.0 | **Ratified**: 2026-03-11 | **Last Amended**: 2026-04-12

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,4 +93,5 @@ Architecture Decision Records are in
 
 ## Active Technologies
 
-- YAML (Ansible 2.19+) + `community.general` collection
+- YAML (Ansible 2.19+) + `community.general` collection + `ansible.builtin.*`;
+  Ubuntu `podman` apt package for rootless containers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ task.
 | [020-rule-confirmation.mdc](.cursor/rules/general/020-rule-confirmation.mdc) | Always applied |
 | [310-collaboration.mdc](.cursor/rules/general/310-collaboration.mdc) | Always applied |
 | [330-git-usage.mdc](.cursor/rules/general/330-git-usage.mdc) | Use for documenting version information and when committing to git |
+| [340-molecule-testing.mdc](.cursor/rules/340-molecule-testing.mdc) | Use when implementing or modifying an Ansible role to set up or maintain its Molecule test scenario |
 | [380-remediation-protocol.mdc](.cursor/rules/general/380-remediation-protocol.mdc) | Use when an unexpected obstacle prevents progress |
 | [400-markdown-formatting.mdc](.cursor/rules/general/400-markdown-formatting.mdc) | Use after creating or modifying a markdown file (`*.md`, `*.mdc`) |
 | [500-cline-memory-bank.mdc](.cursor/rules/general/500-cline-memory-bank.mdc) | Use when following 'follow your custom instructions' to understand the memory bank concept |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,14 +9,22 @@ tools as described in the [Spec Kit Getting Started Guide](https://github.com/gi
 ## Testing a role with Molecule (preferred)
 
 Roles that can be exercised in a container are tested with Molecule. Activate
-the Python virtual environment first, then run from the role directory:
+the Python virtual environment first.
+
+To test a single role, run from the role directory:
 
 ```shell
 cd roles/<role-name>
 molecule test
 ```
 
-This runs the full lifecycle: create → prepare → converge → idempotence →
+To test all roles at once, run from the project root:
+
+```shell
+./scripts/test-molecule-all.sh
+```
+
+Both forms run the full lifecycle: create → prepare → converge → idempotence →
 verify → destroy. All phases MUST pass before committing.
 
 ## Testing a role with Vagrant (fallback for full-VM roles)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,15 +6,30 @@
 can be used to extend this application. Consider installing the corresponding
 tools as described in the [Spec Kit Getting Started Guide](https://github.com/github/spec-kit).
 
-## Easily adding and testing a new role
+## Testing a role with Molecule (preferred)
 
-To test your new role:
+Roles that can be exercised in a container are tested with Molecule. Activate
+the Python virtual environment first, then run from the role directory:
 
-1. Create a tart based VM: [/docs/create-vm.md](./docs/create-vm.md)
-2. Insert the new role in the `configure-linux-roles.yml` playbook
-3. Comment out all other roles in the `configure-linux-roles.yml` playbook, except the new one.
+```shell
+cd roles/<role-name>
+molecule test
+```
 
-Then you can easily run only the new role as follows:
+This runs the full lifecycle: create → prepare → converge → idempotence →
+verify → destroy. All phases MUST pass before committing.
+
+## Testing a role with Vagrant (fallback for full-VM roles)
+
+Roles that require a full VM (e.g., desktop environment, display managers,
+hardware drivers) are tested against a local Vagrant/Tart VM:
+
+1. Create a Tart-based VM: [/docs/create-vm.md](./docs/create-vm.md)
+2. Insert the new role in the `configure-linux-roles.yml` playbook.
+3. Comment out all other roles in `configure-linux-roles.yml`, except the
+   new one.
+
+Then run only the new role:
 
 ```shell
 cd test/tart
@@ -23,4 +38,5 @@ ansible-playbook ../../configure-linux-roles.yml --skip-tags "not-supported-on-v
 
 > [!WARNING]
 >
-> When done, remember to uncomment the other roles in the `configure-linux-roles.yml` playbook.
+> When done, remember to uncomment the other roles in the
+> `configure-linux-roles.yml` playbook.

--- a/REVIEW-FINDINGS.md
+++ b/REVIEW-FINDINGS.md
@@ -1,0 +1,101 @@
+# Review Findings: branch `006-podman-rootless-role`
+
+Reviewed by: technical-coach skill (Claude Code)
+Date: 2026-04-12
+Scope: diff of `006-podman-rootless-role` vs. `main`
+
+## MEDIUM
+
+### M1 — `roles/podman/` has no Molecule scenario, with no documented exemption
+
+Constitution Principle II (v1.2.0, amended on this branch) mandates a
+Molecule test scenario for every role that can be exercised in a container.
+The podman role has no `molecule/` directory.
+
+A legitimate reason exists — installing `podman` inside a Molecule-managed
+Podman container is the "podman-in-podman" problem requiring privileged mode
+not enabled by the driver — but this reason is not recorded anywhere. The
+`lineinfile` and `apt` tasks are testable in a container even if
+`podman system migrate` must be skipped or mocked.
+
+The acceptance test (T020) was also run on the cloud VM `hobbiton` rather
+than a local VM, which brushes against Principle III ("validate locally before
+cloud").
+
+**Action**: Document the exemption in `roles/podman/DESIGN.md` (or add a
+partial Molecule scenario that covers the `apt` and `lineinfile` tasks with
+`podman system migrate` skipped via a variable guard).
+
+### M2 — `prepare.yml` `apt-get update -qq` diverges from rule 340 template
+
+Rule `340-molecule-testing.mdc` (created on this branch) shows the canonical
+bootstrap as `apt-get update` (no flags). The actual `prepare.yml` uses
+`apt-get update -qq`. `techContext.md` documents `apt-get update -qq` (flag
+after subcommand) as potentially failing on Ubuntu 24.04 apt 2.7.x.
+
+T023 passed despite this, so the container image may be more lenient. However,
+the canonical template — the thing future role authors will copy — should be
+safe and self-consistent.
+
+**Action**: Align the template in rule 340 with the implementation (`-qq`), or
+align the implementation with the template (remove `-qq`). The template is the
+safer reference; prefer removing the flag from `prepare.yml`.
+
+## LOW
+
+### L1 — `podman/meta/main.yml` missing `namespace` and `role_name`
+
+The java role required `namespace: wonderbird` and `role_name: java` after
+Molecule prerun failed with a Galaxy naming error. The podman role's
+`meta/main.yml` was written without these fields.
+
+The error does not surface today because the podman role has no Molecule
+scenario, but the moment one is added the prerun will fail for the same reason.
+
+**Action**: Add `namespace: wonderbird` and `role_name: podman` to
+`roles/podman/meta/main.yml`.
+
+### L2 — SDKMAN installer left in `/tmp/` indefinitely with no integrity check
+
+The `Remove sdkman installer` task was correctly removed to fix idempotence.
+However, `/tmp/sdkman-install.sh` (mode `0755`, downloaded from the internet)
+now persists on disk across all subsequent runs, and the `ansible.builtin.get_url`
+task carries no `checksum:` parameter.
+
+**Action**: Register the result of the sdkman install task and conditionally
+delete the script only when install actually ran (`when: install_result is
+changed`). This restores cleanup without breaking idempotence.
+
+## INFO
+
+### I1 — `update_cache` implicit vs. explicit in podman apt task
+
+The podman `apt` task omits `update_cache` (defaults to `no`). The java role's
+new prerequisites task explicitly declares `update_cache: false`. Both behave
+identically; the explicit form is more readable and consistent with the
+emerging project pattern.
+
+**Action**: Add `update_cache: false` to the podman `apt` task.
+
+### I2 — Play-level `become` interplay in `prepare.yml` lacks a comment
+
+`become: true` is declared at play level; the two `raw` tasks override it with
+`become: false` because sudo is not yet installed. The logic is sound but
+subtle — a future reader may "fix" the `become: false` as an apparent mistake.
+
+**Action**: Add a short inline comment to the raw tasks, e.g.:
+`# sudo not yet installed — must not use become`.
+
+## What Is Well Done
+
+- `lineinfile` idempotency strategy for `/etc/subuid`/`/etc/subgid` is correct
+  and well-documented in `DESIGN.md`.
+- `changed_when: false` on `podman system migrate` is the right guard.
+- `requirements.txt` change from `ansible>=4.0.0` to `ansible-core>=2.19.0`
+  is precise; `community.general` is safely covered by `requirements.yml`.
+- The java role Molecule scenario correctly separates `raw` bootstrap tasks
+  and uses `ansible_facts['env']` rather than the removed `ansible_env`.
+- Constitution amendment and rule 340 creation are coherent with each other
+  and with the project's direction.
+- `configure-linux-roles.yml` ordering (`podman` first) is correct for a
+  dependency-providing role.

--- a/configure-linux-roles.yml
+++ b/configure-linux-roles.yml
@@ -12,6 +12,7 @@
   # the caller MUST pass apply: {tags: [not-supported-on-vagrant-arm64]}
   # to propagate the skip tag to inner tasks.
   roles:
+    - podman
     - claude_code
     - role: google_chrome
       tags: not-supported-on-vagrant-arm64

--- a/memory-bank-branches/feat.podman.role/activeContext.md
+++ b/memory-bank-branches/feat.podman.role/activeContext.md
@@ -2,8 +2,9 @@
 
 ## Current Work Focus
 
-Branch `006-podman-rootless-role` — all phases complete, including
-acceptance testing. Ready to commit and open PR.
+Branch `006-podman-rootless-role` — Podman role complete; Molecule test
+scaffold for the `java` role implemented and committed. T023 (running
+`molecule test`) is the remaining acceptance step.
 
 ## Recent Decisions (This Session)
 
@@ -19,11 +20,19 @@ acceptance testing. Ready to commit and open PR.
   prevent unhelpful "undefined variable" errors
 - **DESIGN.md Decision 4** added: documents the shared-start-value trade-off
   for multi-user servers
+- **Molecule test added to `java` role** (T017–T022 complete): this is the
+  primary acceptance criterion that proves Podman is working. Uses
+  `molecule-plugins[podman]`, `ubuntu:24.04`, `testuser`, and verifies
+  `java -version` output contains "Temurin"
+- **`zip`, `unzip`, `curl` prerequisite task** added as first task in
+  `roles/java/tasks/main.yml` (sdkman installer requires these)
+- **SC-005 replaced**: manual Vagrant run replaced by `molecule test` as
+  the authoritative acceptance criterion for the java role
 
 ## Next Steps
 
-1. **Commit** all changes on branch `006-podman-rootless-role`
-2. **Create PR** to merge into `main`
+1. **Run `molecule test`** inside `roles/java/` (T023 — Phase 4 acceptance)
+2. **Create PR** to merge `006-podman-rootless-role` into `main`
 
 ## Active Decisions and Considerations
 
@@ -38,6 +47,11 @@ acceptance testing. Ready to commit and open PR.
   (`awscliv2-public-key.asc`, `install-aws-cli.sh`, etc.) reside inside
   `.devcontainer/`, not the repo root. Correct command:
   `podman build -t devcontainer .devcontainer/`
+- **Molecule prepare.yml** uses `ansible.builtin.raw` (container has no
+  Python before prepare runs); `become: true` at play level is required
+- **verify.yml PATH**: uses
+  `/home/testuser/.sdkman/candidates/java/current/bin:{{ ansible_env.PATH | default(...) }}`
+  to reach the `java` binary
 
 ## Open Questions / Blockers
 
@@ -54,3 +68,7 @@ None.
 - The `speckit.analyze` step surfaces variable-name drift between
   `research.md` and `tasks.md` / `data-model.md` — always run it and fix
   inconsistencies before implementing
+- **`become_user` without task-level `become: true`** is correct in this
+  project: play-level `become: true` is inherited; task-level `become_user`
+  only overrides the target user — do NOT add task-level `become: true` to
+  role tasks (FR-010)

--- a/memory-bank-branches/feat.podman.role/activeContext.md
+++ b/memory-bank-branches/feat.podman.role/activeContext.md
@@ -2,8 +2,8 @@
 
 ## Current Work Focus
 
-Branch `006-podman-rootless-role` — implementation complete, code review
-complete, acceptance testing in progress (Phase 4 of the SDD workflow).
+Branch `006-podman-rootless-role` — all phases complete, including
+acceptance testing. Ready to commit and open PR.
 
 ## Recent Decisions (This Session)
 
@@ -22,17 +22,8 @@ complete, acceptance testing in progress (Phase 4 of the SDD workflow).
 
 ## Next Steps
 
-1. **Run acceptance test T020** against the local VM (the only remaining
-   open task):
-   - SC-001: `podman --version` → version string
-   - SC-002: `podman build -t devcontainer -f .devcontainer/Dockerfile .`
-     → succeeds
-   - SC-003: `podman run --rm devcontainer ansible --version` → version
-     string
-   - SC-004: re-run role → zero `changed` tasks
-2. **Check T020** in `specs/006-podman-rootless-role/tasks.md`
-3. **Commit** all changes on branch `006-podman-rootless-role`
-4. **Create PR** to merge into `main`
+1. **Commit** all changes on branch `006-podman-rootless-role`
+2. **Create PR** to merge into `main`
 
 ## Active Decisions and Considerations
 
@@ -43,10 +34,14 @@ complete, acceptance testing in progress (Phase 4 of the SDD workflow).
   no `registries.conf` configuration required
 - `podman system migrate` runs unconditionally with `changed_when: false`
   (see systemPatterns.md D3 for rationale)
+- **Build context must be `.devcontainer/`**: all `COPY` source files
+  (`awscliv2-public-key.asc`, `install-aws-cli.sh`, etc.) reside inside
+  `.devcontainer/`, not the repo root. Correct command:
+  `podman build -t devcontainer .devcontainer/`
 
 ## Open Questions / Blockers
 
-None. The only open item is the human-run acceptance test (T020).
+None.
 
 ## Patterns and Preferences Learned
 

--- a/memory-bank-branches/feat.podman.role/activeContext.md
+++ b/memory-bank-branches/feat.podman.role/activeContext.md
@@ -1,0 +1,61 @@
+# Active Context — feat.podman.role
+
+## Current Work Focus
+
+Branch `006-podman-rootless-role` — implementation complete, code review
+complete, acceptance testing in progress (Phase 4 of the SDD workflow).
+
+## Recent Decisions (This Session)
+
+- **Rootless Podman chosen** over rootful: no systemd-in-container needed
+  for the `.devcontainer` use case
+- **`test/docker/Dockerfile` dropped from scope**: requires privileged /
+  rootful mode — not needed for the AI agent sandbox goal
+- **`lineinfile` chosen** for subuid/subgid: `ansible.builtin.user` has no
+  subuid support in any released Ansible version; `usermod --add-subuids`
+  is non-idempotent
+- **No docker shim**: caller uses `podman build` / `podman run` directly
+- **`desktop_user_names: []`** added as default in `defaults/main.yml` to
+  prevent unhelpful "undefined variable" errors
+- **DESIGN.md Decision 4** added: documents the shared-start-value trade-off
+  for multi-user servers
+
+## Next Steps
+
+1. **Run acceptance test T020** against the local VM (the only remaining
+   open task):
+   - SC-001: `podman --version` → version string
+   - SC-002: `podman build -t devcontainer -f .devcontainer/Dockerfile .`
+     → succeeds
+   - SC-003: `podman run --rm devcontainer ansible --version` → version
+     string
+   - SC-004: re-run role → zero `changed` tasks
+2. **Check T020** in `specs/006-podman-rootless-role/tasks.md`
+3. **Commit** all changes on branch `006-podman-rootless-role`
+4. **Create PR** to merge into `main`
+
+## Active Decisions and Considerations
+
+- The `# syntax=docker/dockerfile:1` BuildKit directive in
+  `.devcontainer/Dockerfile` is silently ignored by Podman — no workaround
+  needed
+- All image references are fully qualified (`docker.io/python:trixie`) —
+  no `registries.conf` configuration required
+- `podman system migrate` runs unconditionally with `changed_when: false`
+  (see systemPatterns.md D3 for rationale)
+
+## Open Questions / Blockers
+
+None. The only open item is the human-run acceptance test (T020).
+
+## Patterns and Preferences Learned
+
+- Always run `format-markdown` on any `.md` file after editing (constitution
+  Principle VI + rule 400)
+- The `(feature-name)` annotation style in `CLAUDE.md` was rejected — use
+  clean, feature-agnostic bullets in `## Active Technologies`
+- `## Recent Changes` sections in `CLAUDE.md` are forbidden (rule
+  330-git-usage.mdc — git history is authoritative)
+- The `speckit.analyze` step surfaces variable-name drift between
+  `research.md` and `tasks.md` / `data-model.md` — always run it and fix
+  inconsistencies before implementing

--- a/memory-bank-branches/feat.podman.role/activeContext.md
+++ b/memory-bank-branches/feat.podman.role/activeContext.md
@@ -2,32 +2,48 @@
 
 ## Current Work Focus
 
-Branch `006-podman-rootless-role` — all implementation and testing complete.
-Next action: create PR to merge into `main`.
+Branch `006-podman-rootless-role` — implementation complete. A technical code
+review was performed (2026-04-12) and produced findings that must be addressed
+before creating the PR.
 
-## Recent Decisions (This Session)
-
-- **T023 complete**: `molecule test` passes for `roles/java/` — all phases
-  green (prepare, converge, idempotence, verify, destroy)
-- **Molecule fixes applied** to make tests runnable:
-  - `meta/main.yml`: added `namespace: wonderbird`, `role_name: java`
-  - `molecule.yml`: added `ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"`
-  - `prepare.yml`: split `&&`-chained `raw` into two separate tasks; added
-    `become: false` to both (sudo not yet installed during bootstrap)
-  - `tasks/main.yml`: removed unconditional "Remove sdkman installer" task
-    (deleted the file → re-downloaded on idempotence run → not idempotent)
-- **Molecule warnings resolved**:
-  - `molecule.yml`: explicit `test_sequence` omitting unused phases
-  - `verify.yml`: `ansible_env.PATH` → `ansible_facts['env']['PATH']`
-- **Constitution amended** to v1.2.0: Principles II and III updated to
-  require `molecule test` for containerizable roles; Vagrant retained as
-  fallback for full-VM roles
-- **Rule 340-molecule-testing.mdc** created in `.cursor/rules/` and
-  registered in `CLAUDE.md` rule index
+Findings are saved in `REVIEW-FINDINGS.md` at the project root.
 
 ## Next Steps
 
-1. **Create PR** to merge `006-podman-rootless-role` into `main`
+Address review findings in order of severity, then create the PR:
+
+1. **M1** — Document Molecule exemption for `roles/podman/` in `DESIGN.md`
+   (podman-in-podman problem; `apt` + `lineinfile` tasks could be partially
+   tested but `podman system migrate` requires privileged mode not available
+   in the driver). Alternatively, add a partial Molecule scenario that covers
+   the `apt` and `lineinfile` tasks with the `migrate` task skipped via a
+   variable guard.
+2. **M2** — Align `prepare.yml` with rule 340 template: remove `-qq` from
+   `apt-get update -qq` in `roles/java/molecule/default/prepare.yml`.
+3. **L1** — Add `namespace: wonderbird` and `role_name: podman` to
+   `roles/podman/meta/main.yml`.
+4. **L2** — In `roles/java/tasks/main.yml`, register the sdkman install task
+   result and delete `/tmp/sdkman-install.sh` conditionally
+   (`when: install_result is changed`).
+5. **I1** — Add `update_cache: false` to the podman `apt` task in
+   `roles/podman/tasks/main.yml`.
+6. **I2** — Add inline comment to the two `raw` tasks in
+   `roles/java/molecule/default/prepare.yml` explaining `become: false`.
+7. **Create PR** to merge `006-podman-rootless-role` into `main`.
+
+## Review Findings Summary (2026-04-12)
+
+Source: `REVIEW-FINDINGS.md`
+
+- **M1**: No Molecule scenario for `roles/podman/`; exemption not documented
+- **M2**: `prepare.yml` uses `apt-get update -qq`; rule 340 template shows
+  `apt-get update` (no flags) — divergence creates a copy-paste trap
+- **L1**: `podman/meta/main.yml` missing `namespace` and `role_name` (required
+  for Molecule prerun, as learned from java role fix)
+- **L2**: SDKMAN installer `/tmp/sdkman-install.sh` left on disk indefinitely
+  (cleanup task removed to fix idempotence but no conditional replacement added)
+- **I1**: `update_cache` not explicit in podman apt task
+- **I2**: Play-level `become` interplay in `prepare.yml` lacks an explanatory comment
 
 ## Active Decisions and Considerations
 

--- a/memory-bank-branches/feat.podman.role/activeContext.md
+++ b/memory-bank-branches/feat.podman.role/activeContext.md
@@ -10,26 +10,40 @@ Findings are saved in `REVIEW-FINDINGS.md` at the project root.
 
 ## Next Steps
 
-Address review findings in order of severity, then create the PR:
+Address remaining review findings, then create the PR:
 
-1. **M1** — Document Molecule exemption for `roles/podman/` in `DESIGN.md`
-   (podman-in-podman problem; `apt` + `lineinfile` tasks could be partially
-   tested but `podman system migrate` requires privileged mode not available
-   in the driver). Alternatively, add a partial Molecule scenario that covers
-   the `apt` and `lineinfile` tasks with the `migrate` task skipped via a
-   variable guard.
-2. **M2** — Align `prepare.yml` with rule 340 template: remove `-qq` from
-   `apt-get update -qq` in `roles/java/molecule/default/prepare.yml`.
-3. **L1** — Add `namespace: wonderbird` and `role_name: podman` to
-   `roles/podman/meta/main.yml`.
-4. **L2** — In `roles/java/tasks/main.yml`, register the sdkman install task
+1. **M2** — Remove `-qq` from `apt-get update -qq` in
+   `roles/java/molecule/default/prepare.yml` to align with rule 340 template.
+   Also apply `failed_when: false` improvement to
+   `roles/java/molecule/default/verify.yml` for consistency with podman role.
+2. **L2** — In `roles/java/tasks/main.yml`, register the sdkman install task
    result and delete `/tmp/sdkman-install.sh` conditionally
    (`when: install_result is changed`).
-5. **I1** — Add `update_cache: false` to the podman `apt` task in
+3. **I1** — Add `update_cache: false` to the podman `apt` task in
    `roles/podman/tasks/main.yml`.
-6. **I2** — Add inline comment to the two `raw` tasks in
+4. **I2** — Add inline comment to the two `raw` tasks in
    `roles/java/molecule/default/prepare.yml` explaining `become: false`.
-7. **Create PR** to merge `006-podman-rootless-role` into `main`.
+5. **Running all Molecule tests at once** — ask technical-coach how to run
+   all role Molecule tests in a single command (e.g. `molecule test --all`
+   or a loop over roles/).
+6. **Create PR** to merge `006-podman-rootless-role` into `main`.
+
+## Session Progress (2026-04-13)
+
+### Completed this session
+
+- **M1** — Molecule scenario created for `roles/podman/`:
+  - `podman_run_migrate` variable added (`defaults/main.yml`, default `true`)
+  - `when: podman_run_migrate` guard on migrate task
+  - Full scenario: `molecule.yml`, `prepare.yml`, `converge.yml` (sets flag
+    `false`), `verify.yml` (consistent read-then-assert pattern with
+    `failed_when: false` on all command tasks)
+  - `DESIGN.md` updated: headline numbering fixed, exemption documented
+- **L1** — `namespace: wonderbird` and `role_name: podman` added to
+  `roles/podman/meta/main.yml`
+- **`containers.podman` collection** added to `requirements.yml` (>=1.19.2);
+  was missing on fresh machines, broke all Molecule tests
+- Both `roles/podman/` and `roles/java/` Molecule tests pass on `hobbiton`
 
 ## Review Findings Summary (2026-04-12)
 

--- a/memory-bank-branches/feat.podman.role/activeContext.md
+++ b/memory-bank-branches/feat.podman.role/activeContext.md
@@ -2,73 +2,54 @@
 
 ## Current Work Focus
 
-Branch `006-podman-rootless-role` — Podman role complete; Molecule test
-scaffold for the `java` role implemented and committed. T023 (running
-`molecule test`) is the remaining acceptance step.
+Branch `006-podman-rootless-role` — all implementation and testing complete.
+Next action: create PR to merge into `main`.
 
 ## Recent Decisions (This Session)
 
-- **Rootless Podman chosen** over rootful: no systemd-in-container needed
-  for the `.devcontainer` use case
-- **`test/docker/Dockerfile` dropped from scope**: requires privileged /
-  rootful mode — not needed for the AI agent sandbox goal
-- **`lineinfile` chosen** for subuid/subgid: `ansible.builtin.user` has no
-  subuid support in any released Ansible version; `usermod --add-subuids`
-  is non-idempotent
-- **No docker shim**: caller uses `podman build` / `podman run` directly
-- **`desktop_user_names: []`** added as default in `defaults/main.yml` to
-  prevent unhelpful "undefined variable" errors
-- **DESIGN.md Decision 4** added: documents the shared-start-value trade-off
-  for multi-user servers
-- **Molecule test added to `java` role** (T017–T022 complete): this is the
-  primary acceptance criterion that proves Podman is working. Uses
-  `molecule-plugins[podman]`, `ubuntu:24.04`, `testuser`, and verifies
-  `java -version` output contains "Temurin"
-- **`zip`, `unzip`, `curl` prerequisite task** added as first task in
-  `roles/java/tasks/main.yml` (sdkman installer requires these)
-- **SC-005 replaced**: manual Vagrant run replaced by `molecule test` as
-  the authoritative acceptance criterion for the java role
+- **T023 complete**: `molecule test` passes for `roles/java/` — all phases
+  green (prepare, converge, idempotence, verify, destroy)
+- **Molecule fixes applied** to make tests runnable:
+  - `meta/main.yml`: added `namespace: wonderbird`, `role_name: java`
+  - `molecule.yml`: added `ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"`
+  - `prepare.yml`: split `&&`-chained `raw` into two separate tasks; added
+    `become: false` to both (sudo not yet installed during bootstrap)
+  - `tasks/main.yml`: removed unconditional "Remove sdkman installer" task
+    (deleted the file → re-downloaded on idempotence run → not idempotent)
+- **Molecule warnings resolved**:
+  - `molecule.yml`: explicit `test_sequence` omitting unused phases
+  - `verify.yml`: `ansible_env.PATH` → `ansible_facts['env']['PATH']`
+- **Constitution amended** to v1.2.0: Principles II and III updated to
+  require `molecule test` for containerizable roles; Vagrant retained as
+  fallback for full-VM roles
+- **Rule 340-molecule-testing.mdc** created in `.cursor/rules/` and
+  registered in `CLAUDE.md` rule index
 
 ## Next Steps
 
-1. **Run `molecule test`** inside `roles/java/` (T023 — Phase 4 acceptance)
-2. **Create PR** to merge `006-podman-rootless-role` into `main`
+1. **Create PR** to merge `006-podman-rootless-role` into `main`
 
 ## Active Decisions and Considerations
 
-- The `# syntax=docker/dockerfile:1` BuildKit directive in
-  `.devcontainer/Dockerfile` is silently ignored by Podman — no workaround
-  needed
-- All image references are fully qualified (`docker.io/python:trixie`) —
-  no `registries.conf` configuration required
 - `podman system migrate` runs unconditionally with `changed_when: false`
-  (see systemPatterns.md D3 for rationale)
-- **Build context must be `.devcontainer/`**: all `COPY` source files
-  (`awscliv2-public-key.asc`, `install-aws-cli.sh`, etc.) reside inside
-  `.devcontainer/`, not the repo root. Correct command:
-  `podman build -t devcontainer .devcontainer/`
-- **Molecule prepare.yml** uses `ansible.builtin.raw` (container has no
-  Python before prepare runs); `become: true` at play level is required
-- **verify.yml PATH**: uses
-  `/home/testuser/.sdkman/candidates/java/current/bin:{{ ansible_env.PATH | default(...) }}`
-  to reach the `java` binary
-
-## Open Questions / Blockers
-
-None.
+  (see systemPatterns.md D3)
+- Build context must be `.devcontainer/` — not `.`
+- `&&` in YAML `>` folded scalars is unreliable with the Podman connection
+  plugin — always use separate `raw` tasks for bootstrap steps
+- `apt-get -qq update` (flag before subcommand) works; `apt-get update -qq`
+  fails in Ubuntu 24.04 apt 2.7.x ("The update command takes no arguments")
+- `ansible_facts['env']['PATH']` is the correct form; `ansible_env` removed
+  in 2.24
 
 ## Patterns and Preferences Learned
 
-- Always run `format-markdown` on any `.md` file after editing (constitution
-  Principle VI + rule 400)
-- The `(feature-name)` annotation style in `CLAUDE.md` was rejected — use
-  clean, feature-agnostic bullets in `## Active Technologies`
-- `## Recent Changes` sections in `CLAUDE.md` are forbidden (rule
-  330-git-usage.mdc — git history is authoritative)
-- The `speckit.analyze` step surfaces variable-name drift between
-  `research.md` and `tasks.md` / `data-model.md` — always run it and fix
-  inconsistencies before implementing
-- **`become_user` without task-level `become: true`** is correct in this
-  project: play-level `become: true` is inherited; task-level `become_user`
-  only overrides the target user — do NOT add task-level `become: true` to
-  role tasks (FR-010)
+- Always run `format-markdown` on any `.md` file after editing
+- `## Recent Changes` sections in `CLAUDE.md` are forbidden — git history
+  is authoritative
+- `speckit.analyze` surfaces variable-name drift — run before implementing
+- **`become_user` without task-level `become: true`** is correct: play-level
+  `become: true` is inherited
+- The sync impact report HTML comment in constitution.md is required by
+  `speckit.constitution` but can be deleted after review (per project owner)
+- **Molecule subagents** for format-markdown lack Bash access by default —
+  run markdownlint directly in the main session instead

--- a/memory-bank-branches/feat.podman.role/productContext.md
+++ b/memory-bank-branches/feat.podman.role/productContext.md
@@ -1,0 +1,51 @@
+# Product Context — feat.podman.role
+
+## Why This Feature Exists
+
+The developer runs an AI coding agent inside a sandboxed Linux VM to prevent
+the agent from accidentally modifying the host laptop. The agent needs to
+autonomously verify Ansible role acceptance criteria — which requires
+building and running containers from this repository.
+
+Podman is the container runtime chosen because:
+
+- It runs rootless (no daemon, no root privilege required)
+- It is available in the Ubuntu apt package repository
+- `podman build` natively supports the `--mount=type=cache` syntax used in
+  `.devcontainer/Dockerfile` (Podman 4+ / buildah backend)
+- No Docker daemon or systemd socket needed
+
+## Containers in Scope
+
+### `.devcontainer/Dockerfile` — Ansible Control Node
+
+- Base: `docker.io/python:trixie`
+- Purpose: runs Ansible playbooks and CLI tools (AWS CLI, Hetzner CLI)
+- Uses BuildKit cache mounts (`--mount=type=cache`) — supported by Podman
+  natively; the `# syntax=docker/dockerfile:1` comment is silently ignored
+- Built with: `podman build -t devcontainer -f .devcontainer/Dockerfile .`
+
+### `test/docker/Dockerfile` — Test Target (OUT OF SCOPE)
+
+- Base: `ubuntu:24.10` with systemd + SSH
+- Requires privileged / rootful mode to run systemd inside
+- Explicitly excluded from this iteration
+
+## User Experience Goals
+
+After the role is applied to the VM, any user in `desktop_user_names` can:
+
+```bash
+podman build -t devcontainer -f .devcontainer/Dockerfile .
+podman run --rm devcontainer ansible --version
+```
+
+The AI agent uses these commands to verify that the Ansible tooling is
+available before running further automation tasks.
+
+## Broader Vision
+
+The Podman role is a prerequisite for a larger AI agent sandbox feature:
+the agent will use the devcontainer to run Ansible playbooks and acceptance
+tests autonomously, replacing manual acceptance test execution by the
+developer.

--- a/memory-bank-branches/feat.podman.role/productContext.md
+++ b/memory-bank-branches/feat.podman.role/productContext.md
@@ -23,7 +23,7 @@ Podman is the container runtime chosen because:
 - Purpose: runs Ansible playbooks and CLI tools (AWS CLI, Hetzner CLI)
 - Uses BuildKit cache mounts (`--mount=type=cache`) — supported by Podman
   natively; the `# syntax=docker/dockerfile:1` comment is silently ignored
-- Built with: `podman build -t devcontainer -f .devcontainer/Dockerfile .`
+- Built with: `podman build -t devcontainer .devcontainer/`
 
 ### `test/docker/Dockerfile` — Test Target (OUT OF SCOPE)
 
@@ -36,7 +36,7 @@ Podman is the container runtime chosen because:
 After the role is applied to the VM, any user in `desktop_user_names` can:
 
 ```bash
-podman build -t devcontainer -f .devcontainer/Dockerfile .
+podman build -t devcontainer .devcontainer/
 podman run --rm devcontainer ansible --version
 ```
 

--- a/memory-bank-branches/feat.podman.role/progress.md
+++ b/memory-bank-branches/feat.podman.role/progress.md
@@ -2,96 +2,70 @@
 
 ## What Works
 
-### SDD Workflow Phases 1–3 — Complete
+### SDD Workflow Phases 1–4 — Complete
 
-- **Spec** (`specs/006-podman-rootless-role/spec.md`) — 12 functional
-  requirements (FR-001–FR-012), 3 user stories, 4 acceptance criteria
-  (SC-001–SC-004); all clarification findings resolved
+- **Spec** (`specs/006-podman-rootless-role/spec.md`) — FR-001–FR-012, 3
+  user stories, SC-001–SC-004; all clarification findings resolved
 - **Plan** (`specs/006-podman-rootless-role/plan.md`) — constitution check
-  passed (all 6 principles), source layout defined, design decisions
-  documented in `research.md` and `data-model.md`
-- **Tasks** (`specs/006-podman-rootless-role/tasks.md`) — 21 tasks
-  (T001–T021); all checked including T020 (acceptance test)
+  passed, source layout and design decisions documented
+- **Tasks** (`specs/006-podman-rootless-role/tasks.md`) — T001–T021 all ✓
 - **Implementation** (`roles/podman/`) — all role files created and verified
 - **Code review** — all findings (H1, H2, M1, M2, L1, L2, L3) fixed
+- **T020 acceptance test** — all SC-001–SC-004 passed on `hobbiton`
+- **T023 molecule test** — `molecule test` passes for `roles/java/`
 
-### Files Created / Modified
+### Molecule + Java Role (T017–T023) — All Complete
 
-| File | Status |
-| --- | --- |
-| `roles/podman/defaults/main.yml` | Created ✓ |
-| `roles/podman/meta/main.yml` | Created ✓ |
-| `roles/podman/tasks/main.yml` | Created ✓ |
-| `roles/podman/README.md` | Created ✓ |
-| `roles/podman/DESIGN.md` | Created ✓ |
-| `configure-linux-roles.yml` | Modified (podman added) ✓ |
-| `CLAUDE.md` | Modified (Active Technologies updated) ✓ |
-| `specs/006-podman-rootless-role/` | All 6 spec artifacts ✓ |
-| `roles/java/tasks/main.yml` | Modified (prerequisites task added) ✓ |
-| `roles/java/molecule/default/molecule.yml` | Created ✓ |
-| `roles/java/molecule/default/prepare.yml` | Created ✓ |
-| `roles/java/molecule/default/converge.yml` | Created ✓ |
-| `roles/java/molecule/default/verify.yml` | Created ✓ |
-| `requirements.txt` | Modified (molecule deps added) ✓ |
-| `specs/005-java-role/spec.md` | Modified (FR-013–FR-019, SC-005) ✓ |
-| `specs/005-java-role/plan.md` | Modified (Molecule references) ✓ |
-| `specs/005-java-role/tasks.md` | Modified (T017–T023) ✓ |
+| Task | Description | Status |
+| --- | --- | --- |
+| T017 | Add zip/unzip/curl prerequisite to java role | ✓ |
+| T018 | Create molecule.yml (podman driver, ubuntu:24.04) | ✓ |
+| T019 | Create prepare.yml (python3, sudo, testuser) | ✓ |
+| T020 | Create converge.yml | ✓ |
+| T021 | Create verify.yml (java -version → Temurin) | ✓ |
+| T022 | Update requirements.txt with molecule deps | ✓ |
+| T023 | Run molecule test — acceptance test | ✓ |
+
+### Molecule Fixes (post-generation)
+
+| Fix | File | Symptom resolved |
+| --- | --- | --- |
+| Added namespace + role_name | `meta/main.yml` | Galaxy naming error |
+| Added ANSIBLE_ROLES_PATH | `molecule.yml` | Role not found in syntax check |
+| Split raw tasks; become: false | `prepare.yml` | sudo not found / apt error |
+| Removed Remove sdkman installer | `tasks/main.yml` | Idempotence failure |
+| Explicit test_sequence | `molecule.yml` | Missing-phase warnings |
+| ansible_facts['env'] | `verify.yml` | Deprecation warning |
+
+### Standards Work
+
+- Constitution amended to v1.2.0 (Molecule testing standard)
+- Rule `340-molecule-testing.mdc` created and registered in `CLAUDE.md`
+- `CONTRIBUTING.md` restructured (Molecule primary, Vagrant fallback)
 
 ## What's Left to Build
 
-### T020 — Acceptance Test Against Hetzner VM (COMPLETE)
-
-All four acceptance criteria passed against `hobbiton` (Hetzner Cloud,
-Ubuntu, `galadriel` user):
-
-- [X] SC-001: `podman --version` → `podman version 4.9.3`
-- [X] SC-002: `podman build -t devcontainer .devcontainer/` → build succeeded
-- [X] SC-002b: `podman run --rm devcontainer ansible --version`
-  → `ansible [core 2.20.4]`
-- [X] SC-003: second role run → zero `changed` tasks
-- [X] SC-004: `/etc/subuid` and `/etc/subgid` contain `galadriel:100000:65536`
-
-**Finding**: the build context must be `.devcontainer/` (not `.`), because
-all `COPY` source files reside in `.devcontainer/`. Documentation corrected
-in `spec.md`, `quickstart.md`, and `productContext.md`.
-
-### After T020 (Podman role)
-
-- [X] Check T020 in `tasks.md`
-
-### Molecule + Java Role Extension (T017–T023)
-
-- [X] T017: Added `zip`/`unzip`/`curl` prerequisite task as first task in
-  `roles/java/tasks/main.yml`
-- [X] T018: Created `roles/java/molecule/default/molecule.yml` (podman
-  driver, ubuntu:24.04 platform)
-- [X] T019: Created `roles/java/molecule/default/prepare.yml` (python3,
-  sudo, testuser via raw + user module)
-- [X] T020: Created `roles/java/molecule/default/converge.yml`
-- [X] T021: Created `roles/java/molecule/default/verify.yml` (java
-  -version → Temurin assertion)
-- [X] T022: Updated `requirements.txt` with molecule dependencies;
-  `ansible>=4.0.0` tightened to `ansible-core>=2.19.0`
-- [X] Committed and pushed all changes
-- [ ] T023: Run `molecule test` — acceptance test (Phase 4)
 - [ ] Create PR to merge `006-podman-rootless-role` into `main`
 
 ## Current Status
 
 **Branch**: `006-podman-rootless-role`
-**Phase**: 4 — Acceptance Test pending (T023); all implementation complete
+**Phase**: Complete — PR creation is the only remaining step
 **Blocker**: none
 
 ## Known Issues
 
-None identified during implementation or code review.
+None.
 
 ## Evolution of Project Decisions
 
-1. Initially assumed `ansible.builtin.user` could manage subuid/subgid —
-   confirmed via expert subagent that no released Ansible version supports
-   this; pivoted to `lineinfile`
-2. `test/docker/Dockerfile` dropped from scope after learning the rootless
-   constraint (systemd-in-container needs privileged / rootful mode)
-3. Overlapping subuid ranges (all users share start=100000) is intentional
-   for the single-person workstation use case — documented in DESIGN.md D4
+1. `ansible.builtin.user` cannot manage subuid/subgid — pivoted to
+   `lineinfile`
+2. `test/docker/Dockerfile` dropped from scope (needs rootful mode)
+3. Overlapping subuid ranges intentional for single-person workstation
+   (YAGNI) — documented in DESIGN.md D4
+4. `&&` in YAML `>` folded scalars unreliable with Podman connection plugin
+   — split into separate `raw` tasks
+5. `apt-get update -qq` fails in Ubuntu 24.04 apt 2.7.x — flag must precede
+   subcommand; simplest fix is removing `-qq` entirely
+6. Unconditional installer cleanup breaks idempotence — removed the task

--- a/memory-bank-branches/feat.podman.role/progress.md
+++ b/memory-bank-branches/feat.podman.role/progress.md
@@ -47,27 +47,29 @@
 
 Review findings from 2026-04-12 technical code review (see `REVIEW-FINDINGS.md`):
 
-- [ ] **M1** — Document Molecule exemption for `roles/podman/` in `DESIGN.md`
-      (podman-in-podman problem prevents full Molecule test; `apt` + `lineinfile`
-      tasks could be partially tested)
-- [ ] **M2** — Remove `-qq` from `apt-get update -qq` in
-      `roles/java/molecule/default/prepare.yml` to align with rule 340 template
-- [ ] **L1** — Add `namespace: wonderbird` and `role_name: podman` to
+- [x] **M1** — Molecule scenario added for `roles/podman/`; `podman_run_migrate`
+      flag guards migrate task; exemption documented in `DESIGN.md`
+- [x] **L1** — `namespace: wonderbird` and `role_name: podman` added to
       `roles/podman/meta/main.yml`
+- [ ] **M2** — Remove `-qq` from `apt-get update -qq` in
+      `roles/java/molecule/default/prepare.yml` to align with rule 340 template.
+      Also apply `failed_when: false` to `roles/java/molecule/default/verify.yml`
+      for consistency with podman role.
 - [ ] **L2** — Conditionally delete `/tmp/sdkman-install.sh` in
       `roles/java/tasks/main.yml` (register install result; `when: changed`)
 - [ ] **I1** — Add `update_cache: false` to podman `apt` task in
       `roles/podman/tasks/main.yml`
 - [ ] **I2** — Add `become: false` comment to raw tasks in
       `roles/java/molecule/default/prepare.yml`
+- [ ] **Ask**: how to run all Molecule tests at once (loop over `roles/` or
+      built-in Molecule command)
 - [ ] Create PR to merge `006-podman-rootless-role` into `main`
 
 ## Current Status
 
 **Branch**: `006-podman-rootless-role`
-**Phase**: Post-review remediation — 6 findings to address before PR
-**Blocker**: none (review findings are improvements, not blockers — but should
-be resolved before merge per project quality standards)
+**Phase**: Post-review remediation — M1 + L1 done; 4 findings + PR remaining
+**Blocker**: none
 
 ## Known Issues
 

--- a/memory-bank-branches/feat.podman.role/progress.md
+++ b/memory-bank-branches/feat.podman.role/progress.md
@@ -1,0 +1,71 @@
+# Progress — feat.podman.role
+
+## What Works
+
+### SDD Workflow Phases 1–3 — Complete
+
+- **Spec** (`specs/006-podman-rootless-role/spec.md`) — 12 functional
+  requirements (FR-001–FR-012), 3 user stories, 4 acceptance criteria
+  (SC-001–SC-004); all clarification findings resolved
+- **Plan** (`specs/006-podman-rootless-role/plan.md`) — constitution check
+  passed (all 6 principles), source layout defined, design decisions
+  documented in `research.md` and `data-model.md`
+- **Tasks** (`specs/006-podman-rootless-role/tasks.md`) — 21 tasks
+  (T001–T021); T001–T019 and T021 checked; T020 (acceptance test) open
+- **Implementation** (`roles/podman/`) — all role files created and verified
+- **Code review** — all findings (H1, H2, M1, M2, L1, L2, L3) fixed
+
+### Files Created / Modified
+
+| File | Status |
+| --- | --- |
+| `roles/podman/defaults/main.yml` | Created ✓ |
+| `roles/podman/meta/main.yml` | Created ✓ |
+| `roles/podman/tasks/main.yml` | Created ✓ |
+| `roles/podman/README.md` | Created ✓ |
+| `roles/podman/DESIGN.md` | Created ✓ |
+| `configure-linux-roles.yml` | Modified (podman added) ✓ |
+| `CLAUDE.md` | Modified (Active Technologies updated) ✓ |
+| `specs/006-podman-rootless-role/` | All 6 spec artifacts ✓ |
+
+## What's Left to Build
+
+### T020 — Acceptance Test Against Local VM (OPEN)
+
+Run the full acceptance test checklist from
+`specs/006-podman-rootless-role/quickstart.md`:
+
+- [ ] SC-001: `podman --version` succeeds for each user in
+  `desktop_user_names`
+- [ ] SC-002: `podman build -t devcontainer -f .devcontainer/Dockerfile .`
+  succeeds
+- [ ] SC-003: `podman run --rm devcontainer ansible --version` prints a
+  version string
+- [ ] SC-004: second role run reports zero `changed` tasks
+
+### After T020
+
+- [ ] Check T020 in `tasks.md`
+- [ ] Commit all changes (conventional commit: `feat: add podman role for
+  rootless container support`)
+- [ ] Create PR to merge `006-podman-rootless-role` into `main`
+
+## Current Status
+
+**Branch**: `006-podman-rootless-role`
+**Phase**: 4 — Acceptance Test (in progress)
+**Blocker**: human must run T020 against local VM
+
+## Known Issues
+
+None identified during implementation or code review.
+
+## Evolution of Project Decisions
+
+1. Initially assumed `ansible.builtin.user` could manage subuid/subgid —
+   confirmed via expert subagent that no released Ansible version supports
+   this; pivoted to `lineinfile`
+2. `test/docker/Dockerfile` dropped from scope after learning the rootless
+   constraint (systemd-in-container needs privileged / rootful mode)
+3. Overlapping subuid ranges (all users share start=100000) is intentional
+   for the single-person workstation use case — documented in DESIGN.md D4

--- a/memory-bank-branches/feat.podman.role/progress.md
+++ b/memory-bank-branches/feat.podman.role/progress.md
@@ -45,17 +45,33 @@
 
 ## What's Left to Build
 
+Review findings from 2026-04-12 technical code review (see `REVIEW-FINDINGS.md`):
+
+- [ ] **M1** — Document Molecule exemption for `roles/podman/` in `DESIGN.md`
+      (podman-in-podman problem prevents full Molecule test; `apt` + `lineinfile`
+      tasks could be partially tested)
+- [ ] **M2** — Remove `-qq` from `apt-get update -qq` in
+      `roles/java/molecule/default/prepare.yml` to align with rule 340 template
+- [ ] **L1** — Add `namespace: wonderbird` and `role_name: podman` to
+      `roles/podman/meta/main.yml`
+- [ ] **L2** — Conditionally delete `/tmp/sdkman-install.sh` in
+      `roles/java/tasks/main.yml` (register install result; `when: changed`)
+- [ ] **I1** — Add `update_cache: false` to podman `apt` task in
+      `roles/podman/tasks/main.yml`
+- [ ] **I2** — Add `become: false` comment to raw tasks in
+      `roles/java/molecule/default/prepare.yml`
 - [ ] Create PR to merge `006-podman-rootless-role` into `main`
 
 ## Current Status
 
 **Branch**: `006-podman-rootless-role`
-**Phase**: Complete — PR creation is the only remaining step
-**Blocker**: none
+**Phase**: Post-review remediation — 6 findings to address before PR
+**Blocker**: none (review findings are improvements, not blockers — but should
+be resolved before merge per project quality standards)
 
 ## Known Issues
 
-None.
+None beyond the review findings listed above.
 
 ## Evolution of Project Decisions
 

--- a/memory-bank-branches/feat.podman.role/progress.md
+++ b/memory-bank-branches/feat.podman.role/progress.md
@@ -27,6 +27,15 @@
 | `configure-linux-roles.yml` | Modified (podman added) ✓ |
 | `CLAUDE.md` | Modified (Active Technologies updated) ✓ |
 | `specs/006-podman-rootless-role/` | All 6 spec artifacts ✓ |
+| `roles/java/tasks/main.yml` | Modified (prerequisites task added) ✓ |
+| `roles/java/molecule/default/molecule.yml` | Created ✓ |
+| `roles/java/molecule/default/prepare.yml` | Created ✓ |
+| `roles/java/molecule/default/converge.yml` | Created ✓ |
+| `roles/java/molecule/default/verify.yml` | Created ✓ |
+| `requirements.txt` | Modified (molecule deps added) ✓ |
+| `specs/005-java-role/spec.md` | Modified (FR-013–FR-019, SC-005) ✓ |
+| `specs/005-java-role/plan.md` | Modified (Molecule references) ✓ |
+| `specs/005-java-role/tasks.md` | Modified (T017–T023) ✓ |
 
 ## What's Left to Build
 
@@ -46,16 +55,31 @@ Ubuntu, `galadriel` user):
 all `COPY` source files reside in `.devcontainer/`. Documentation corrected
 in `spec.md`, `quickstart.md`, and `productContext.md`.
 
-### After T020
+### After T020 (Podman role)
 
 - [X] Check T020 in `tasks.md`
-- [ ] Commit all changes
+
+### Molecule + Java Role Extension (T017–T023)
+
+- [X] T017: Added `zip`/`unzip`/`curl` prerequisite task as first task in
+  `roles/java/tasks/main.yml`
+- [X] T018: Created `roles/java/molecule/default/molecule.yml` (podman
+  driver, ubuntu:24.04 platform)
+- [X] T019: Created `roles/java/molecule/default/prepare.yml` (python3,
+  sudo, testuser via raw + user module)
+- [X] T020: Created `roles/java/molecule/default/converge.yml`
+- [X] T021: Created `roles/java/molecule/default/verify.yml` (java
+  -version → Temurin assertion)
+- [X] T022: Updated `requirements.txt` with molecule dependencies;
+  `ansible>=4.0.0` tightened to `ansible-core>=2.19.0`
+- [X] Committed and pushed all changes
+- [ ] T023: Run `molecule test` — acceptance test (Phase 4)
 - [ ] Create PR to merge `006-podman-rootless-role` into `main`
 
 ## Current Status
 
 **Branch**: `006-podman-rootless-role`
-**Phase**: 4 — Acceptance Test complete; ready to commit and open PR
+**Phase**: 4 — Acceptance Test pending (T023); all implementation complete
 **Blocker**: none
 
 ## Known Issues

--- a/memory-bank-branches/feat.podman.role/progress.md
+++ b/memory-bank-branches/feat.podman.role/progress.md
@@ -11,7 +11,7 @@
   passed (all 6 principles), source layout defined, design decisions
   documented in `research.md` and `data-model.md`
 - **Tasks** (`specs/006-podman-rootless-role/tasks.md`) — 21 tasks
-  (T001–T021); T001–T019 and T021 checked; T020 (acceptance test) open
+  (T001–T021); all checked including T020 (acceptance test)
 - **Implementation** (`roles/podman/`) — all role files created and verified
 - **Code review** — all findings (H1, H2, M1, M2, L1, L2, L3) fixed
 
@@ -30,31 +30,33 @@
 
 ## What's Left to Build
 
-### T020 — Acceptance Test Against Local VM (OPEN)
+### T020 — Acceptance Test Against Hetzner VM (COMPLETE)
 
-Run the full acceptance test checklist from
-`specs/006-podman-rootless-role/quickstart.md`:
+All four acceptance criteria passed against `hobbiton` (Hetzner Cloud,
+Ubuntu, `galadriel` user):
 
-- [ ] SC-001: `podman --version` succeeds for each user in
-  `desktop_user_names`
-- [ ] SC-002: `podman build -t devcontainer -f .devcontainer/Dockerfile .`
-  succeeds
-- [ ] SC-003: `podman run --rm devcontainer ansible --version` prints a
-  version string
-- [ ] SC-004: second role run reports zero `changed` tasks
+- [X] SC-001: `podman --version` → `podman version 4.9.3`
+- [X] SC-002: `podman build -t devcontainer .devcontainer/` → build succeeded
+- [X] SC-002b: `podman run --rm devcontainer ansible --version`
+  → `ansible [core 2.20.4]`
+- [X] SC-003: second role run → zero `changed` tasks
+- [X] SC-004: `/etc/subuid` and `/etc/subgid` contain `galadriel:100000:65536`
+
+**Finding**: the build context must be `.devcontainer/` (not `.`), because
+all `COPY` source files reside in `.devcontainer/`. Documentation corrected
+in `spec.md`, `quickstart.md`, and `productContext.md`.
 
 ### After T020
 
-- [ ] Check T020 in `tasks.md`
-- [ ] Commit all changes (conventional commit: `feat: add podman role for
-  rootless container support`)
+- [X] Check T020 in `tasks.md`
+- [ ] Commit all changes
 - [ ] Create PR to merge `006-podman-rootless-role` into `main`
 
 ## Current Status
 
 **Branch**: `006-podman-rootless-role`
-**Phase**: 4 — Acceptance Test (in progress)
-**Blocker**: human must run T020 against local VM
+**Phase**: 4 — Acceptance Test complete; ready to commit and open PR
+**Blocker**: none
 
 ## Known Issues
 

--- a/memory-bank-branches/feat.podman.role/projectbrief.md
+++ b/memory-bank-branches/feat.podman.role/projectbrief.md
@@ -1,0 +1,40 @@
+# Project Brief — feat.podman.role
+
+## Project
+
+`ansible-all-my-things` — an Ansible automation repository that provisions
+Linux (Ubuntu) and Windows Server machines on local VMs (Vagrant + Tart /
+Docker) and cloud targets (AWS EC2, Hetzner Cloud).
+
+## Iteration Goal
+
+Add a `podman` Ansible role that installs rootless Podman on an Ubuntu Linux
+VM, so that an AI coding agent running inside that VM can build and run the
+Docker-compatible containers shipped with this repository.
+
+## Problem Statement
+
+The developer wants to run an AI coding agent (e.g. Claude Code) inside a
+sandboxed Linux VM. The sandbox prevents the agent from modifying the host
+laptop. The agent needs to execute acceptance tests for Ansible roles
+autonomously — without the developer manually running commands. Podman is
+the container runtime that enables the agent to build the Ansible control
+node container (`.devcontainer/Dockerfile`) and spin up test targets.
+
+## Scope
+
+- New role: `roles/podman/`
+- Install Podman via Ubuntu `apt`
+- Configure rootless Podman per-user (loop over `desktop_user_names`)
+- Manage `/etc/subuid` and `/etc/subgid` with `ansible.builtin.lineinfile`
+- No Docker compatibility shim; `podman build` / `podman run` directly
+- Only `.devcontainer/Dockerfile` is in scope; `test/docker/Dockerfile`
+  (systemd-based) is explicitly out of scope for this iteration
+
+## Out of Scope
+
+- Running containers with systemd inside (privileged / rootful mode)
+- `podman-docker` shim
+- `registries.conf` customisation
+- `loginctl enable-linger` (no container services, interactive use only)
+- Ubuntu version pre-flight assert

--- a/memory-bank-branches/feat.podman.role/systemPatterns.md
+++ b/memory-bank-branches/feat.podman.role/systemPatterns.md
@@ -1,0 +1,99 @@
+# System Patterns — feat.podman.role
+
+## Role Structure
+
+Follows the project-wide pattern for Linux roles:
+
+```text
+roles/podman/
+├── defaults/
+│   └── main.yml        # four role variables + desktop_user_names default
+├── meta/
+│   └── main.yml        # galaxy_info, MIT-0 licence, Ubuntu platform
+├── tasks/
+│   └── main.yml        # four tasks (see below)
+├── DESIGN.md           # non-obvious design decisions (FR-012)
+└── README.md           # variables table, example playbook, licence
+```
+
+## Task Flow
+
+```text
+apt install podman
+    │
+    ▼
+lineinfile /etc/subuid  ← loop over desktop_user_names
+    │
+    ▼
+lineinfile /etc/subgid  ← loop over desktop_user_names
+    │
+    ▼
+podman system migrate   ← loop over desktop_user_names
+                          changed_when: false
+```
+
+## Key Design Decisions
+
+### D1 — Package source: Ubuntu apt
+
+Podman is installed via `ansible.builtin.apt` (`state: present`, not
+`latest`). No PPA needed — Ubuntu 22.04+ ships Podman 3.4+; Ubuntu 24.04+
+ships Podman 4.x, which supports `--mount=type=cache` natively.
+
+### D2 — subuid/subgid via lineinfile (not usermod)
+
+`ansible.builtin.user` has no subuid/subgid support in any released Ansible
+version. `usermod --add-subuids` is non-idempotent (duplicates on re-run).
+`ansible.builtin.lineinfile` with `regexp: '^{{ item }}:'` is fully
+idempotent and declarative — it enforces the exact `username:start:count`
+line, replacing any differing value in-place.
+
+### D3 — podman system migrate: unconditional with changed_when: false
+
+Runs on every playbook execution. Always reports `ok` (never `changed`),
+making it safe to re-run. A handler would suppress migration on idempotency
+re-runs where no `changed` signal is emitted. Avoids introducing a
+`handlers/` directory for a single side-effect-free command.
+
+### D4 — Shared subuid/subgid start value (100000) for all users
+
+Single-person workstation use case: YAGNI. All users in `desktop_user_names`
+share start=100000, count=65536. Callers on multi-user servers must override
+`podman_subuid_start` / `podman_subgid_start` per user via `host_vars` or
+`group_vars` if non-overlapping ranges are required.
+
+### D5 — No docker shim, no registries.conf, no linger
+
+- No `podman-docker`: callers use `podman build` / `podman run` directly
+- No `registries.conf`: all image refs are fully qualified (`docker.io/…`)
+- No `loginctl enable-linger`: interactive use only, not container services
+
+## Role Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `podman_subuid_start` | `100000` | First sub-UID allocated per user |
+| `podman_subuid_count` | `65536` | Number of sub-UIDs allocated |
+| `podman_subgid_start` | `100000` | First sub-GID allocated per user |
+| `podman_subgid_count` | `65536` | Number of sub-GIDs allocated |
+| `desktop_user_names` | `[]` | Users to configure for rootless Podman |
+
+## Idempotency Mechanisms
+
+| Task | Guard |
+| --- | --- |
+| `apt install podman` | `state: present` |
+| `lineinfile /etc/subuid` | `regexp: '^{{ item }}:'` |
+| `lineinfile /etc/subgid` | `regexp: '^{{ item }}:'` |
+| `podman system migrate` | `changed_when: false` |
+
+## Playbook Integration
+
+The role is the first entry in `configure-linux-roles.yml`:
+
+```yaml
+roles:
+  - role: podman
+```
+
+`become: true` is set at play level — the role does not set it per-task.

--- a/memory-bank-branches/feat.podman.role/systemPatterns.md
+++ b/memory-bank-branches/feat.podman.role/systemPatterns.md
@@ -87,6 +87,19 @@ share start=100000, count=65536. Callers on multi-user servers must override
 | `lineinfile /etc/subgid` | `regexp: '^{{ item }}:'` |
 | `podman system migrate` | `changed_when: false` |
 
+## Molecule Scenario Pattern (java role)
+
+```text
+roles/java/molecule/default/
+├── molecule.yml   # podman driver, ubuntu:24.04, ANSIBLE_ROLES_PATH, test_sequence
+├── prepare.yml    # two raw tasks (update cache, install python3+sudo); become: false
+├── converge.yml   # applies the java role with desktop_user_names: [testuser]
+└── verify.yml     # runs java -version as testuser; asserts "Temurin" in output
+```
+
+`meta/main.yml` must declare `namespace: wonderbird` and `role_name: java`
+or Molecule's prerun fails.
+
 ## Playbook Integration
 
 The role is the first entry in `configure-linux-roles.yml`:

--- a/memory-bank-branches/feat.podman.role/techContext.md
+++ b/memory-bank-branches/feat.podman.role/techContext.md
@@ -63,6 +63,21 @@ All located at `specs/006-podman-rootless-role/`:
 - Architecture: the Ubuntu `podman` apt package supports AMD64 and ARM64
   natively — no architecture branching needed
 
+## Molecule Testing
+
+- **Versions**: `molecule>=24.0.0`, `molecule-plugins[podman]>=23.0.0`
+- **Driver**: `podman` — requires `podman` binary in PATH (Ubuntu apt)
+- **Test command**: `cd roles/<role-name> && molecule test`
+- **Rule file**: `.cursor/rules/340-molecule-testing.mdc`
+- **Key pitfalls**:
+  - `&&` in YAML `>` folded scalars unreliable with Podman connection plugin
+    → use separate `raw` tasks
+  - `apt-get update -qq` fails in Ubuntu 24.04 apt 2.7.x → use `apt-get update`
+  - `become: true` at play level tries sudo before sudo is installed → add
+    `become: false` to bootstrap `raw` tasks
+  - Unconditional file deletion (cleanup tasks) breaks idempotence
+  - Use `ansible_facts['env']['PATH']` not `ansible_env.PATH` (removed 2.24)
+
 ## File Conventions
 
 - YAML files: `#SPDX-License-Identifier: MIT-0` (no space after `#`)

--- a/memory-bank-branches/feat.podman.role/techContext.md
+++ b/memory-bank-branches/feat.podman.role/techContext.md
@@ -18,11 +18,25 @@
 - SSH target configured for `vagrant` user
 - `configure-linux-roles.yml` used to apply the role in isolation
 
+### Acceptance Test (T020) — Actual Execution
+
+T020 was run against the Hetzner Cloud VM `hobbiton` (Ubuntu, `galadriel`
+user) instead of a local Vagrant VM. All four criteria passed:
+
+- Podman 4.9.3 installed; `podman --version` succeeded
+- `/etc/subuid` and `/etc/subgid` contain `galadriel:100000:65536`
+- `podman build -t devcontainer .devcontainer/` succeeded
+- `podman run --rm devcontainer ansible --version` → `ansible [core 2.20.4]`
+- Second playbook run: zero `changed` tasks
+
+Command used: `ansible-playbook configure-linux-roles.yml --limit hobbiton`
+(no `-i` flag needed; `ansible.cfg` sets `inventory = ./inventories`)
+
 ### Test Procedure (from CONTRIBUTING.md)
 
 1. Isolate the role: ensure only `podman` is active in
    `configure-linux-roles.yml`
-2. Run: `ansible-playbook configure-linux-roles.yml -i inventories/local`
+2. Run: `ansible-playbook configure-linux-roles.yml --limit <target>`
 3. Verify all four acceptance criteria (see `specs/006-podman-rootless-role/
    quickstart.md`)
 

--- a/memory-bank-branches/feat.podman.role/techContext.md
+++ b/memory-bank-branches/feat.podman.role/techContext.md
@@ -1,0 +1,56 @@
+# Tech Context — feat.podman.role
+
+## Technologies Used
+
+- **Ansible 2.19+** — automation engine; all modules use `ansible.builtin.*`
+  FQCNs; no Galaxy collections required for this role
+- **Podman 4.x** — rootless container runtime; installed from Ubuntu apt
+- **Ubuntu 22.04 LTS / 24.04 LTS** — primary target OS (24.04 ships
+  Podman 4.x with native `--mount=type=cache` support)
+- **buildah** (bundled with Podman) — OCI build backend; handles
+  `RUN --mount=type=cache` without external BuildKit
+
+## Development Setup
+
+### Local Test VM
+
+- Vagrant + Docker (Linux hosts) or Vagrant + Tart (macOS ARM64 hosts)
+- SSH target configured for `vagrant` user
+- `configure-linux-roles.yml` used to apply the role in isolation
+
+### Test Procedure (from CONTRIBUTING.md)
+
+1. Isolate the role: ensure only `podman` is active in
+   `configure-linux-roles.yml`
+2. Run: `ansible-playbook configure-linux-roles.yml -i inventories/local`
+3. Verify all four acceptance criteria (see `specs/006-podman-rootless-role/
+   quickstart.md`)
+
+## Spec Artifacts
+
+All located at `specs/006-podman-rootless-role/`:
+
+| File | Purpose |
+| --- | --- |
+| `spec.md` | Functional requirements, user stories, acceptance criteria |
+| `plan.md` | Technical context, constitution check, source layout |
+| `tasks.md` | 21 implementation tasks (T001–T021) |
+| `research.md` | 6 resolved design decisions |
+| `data-model.md` | Role variables, system file entities, task-flow diagram |
+| `quickstart.md` | Local VM test procedure, acceptance test checklist |
+
+## Constraints
+
+- `become: true` must be set at play level (role does not set it per-task)
+- `desktop_user_names` must contain valid system users; the role does not
+  validate user existence (YAGNI) — an orphaned `/etc/subuid` entry is
+  the failure mode for non-existent users
+- Ansible Vault: not relevant for this role (no secrets)
+- Architecture: the Ubuntu `podman` apt package supports AMD64 and ARM64
+  natively — no architecture branching needed
+
+## File Conventions
+
+- YAML files: `#SPDX-License-Identifier: MIT-0` (no space after `#`)
+- Markdown files: ATX headings, blank lines around lists, no trailing
+  whitespace, one trailing newline, max 80 chars per line (MD013)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Multi-provider infrastructure automation
 
 # Core Ansible dependencies
-ansible>=4.0.0
+ansible-core>=2.19.0
 
 # AWS provider support
 boto3>=1.26.0
@@ -17,3 +17,7 @@ hcloud>=1.16.0
 # Additional utilities
 requests>=2.25.0
 PyYAML>=5.4.0
+
+# Molecule test dependencies
+molecule>=24.0.0
+molecule-plugins[podman]>=23.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,3 +10,5 @@ collections:
     version: ">=1.0.0"
   - name: community.windows
     version: ">=1.0.0"
+  - name: containers.podman
+    version: ">=1.19.2"

--- a/roles/java/meta/main.yml
+++ b/roles/java/meta/main.yml
@@ -1,6 +1,8 @@
 #SPDX-License-Identifier: MIT-0
 galaxy_info:
   author: Stefan Boos
+  namespace: wonderbird
+  role_name: java
   description: Install sdkman and Temurin JDK for every user in desktop_user_names
   company: n.a.
   issue_tracker_url: https://github.com/wonderbird/ansible-all-my-things/issues

--- a/roles/java/molecule/default/converge.yml
+++ b/roles/java/molecule/default/converge.yml
@@ -1,0 +1,10 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    desktop_user_names:
+      - testuser
+  roles:
+    - role: java

--- a/roles/java/molecule/default/molecule.yml
+++ b/roles/java/molecule/default/molecule.yml
@@ -10,5 +10,7 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
 verifier:
   name: ansible

--- a/roles/java/molecule/default/molecule.yml
+++ b/roles/java/molecule/default/molecule.yml
@@ -1,0 +1,14 @@
+#SPDX-License-Identifier: MIT-0
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: docker.io/library/ubuntu:24.04
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/roles/java/molecule/default/molecule.yml
+++ b/roles/java/molecule/default/molecule.yml
@@ -14,3 +14,13 @@ provisioner:
     ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
 verifier:
   name: ansible
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/roles/java/molecule/default/prepare.yml
+++ b/roles/java/molecule/default/prepare.yml
@@ -6,12 +6,14 @@
   become: true
   tasks:
     - name: Update apt cache
-      ansible.builtin.raw: apt-get update -qq
+      ansible.builtin.raw: apt-get update
+      # become: false — sudo is not yet installed; run directly as root
       become: false
       changed_when: true
 
     - name: Install python3 and sudo
       ansible.builtin.raw: apt-get install -y -qq python3 sudo
+      # become: false — sudo is not yet installed; run directly as root
       become: false
       changed_when: true
 

--- a/roles/java/molecule/default/prepare.yml
+++ b/roles/java/molecule/default/prepare.yml
@@ -5,10 +5,14 @@
   gather_facts: false
   become: true
   tasks:
+    - name: Update apt cache
+      ansible.builtin.raw: apt-get update -qq
+      become: false
+      changed_when: true
+
     - name: Install python3 and sudo
-      ansible.builtin.raw: >
-        apt-get update -qq &&
-        apt-get install -y -qq python3 sudo
+      ansible.builtin.raw: apt-get install -y -qq python3 sudo
+      become: false
       changed_when: true
 
     - name: Create testuser

--- a/roles/java/molecule/default/prepare.yml
+++ b/roles/java/molecule/default/prepare.yml
@@ -1,0 +1,18 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Prepare container
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Install python3 and sudo
+      ansible.builtin.raw: >
+        apt-get update -qq &&
+        apt-get install -y -qq python3 sudo
+      changed_when: true
+
+    - name: Create testuser
+      ansible.builtin.user:
+        name: testuser
+        state: present
+        create_home: true

--- a/roles/java/molecule/default/verify.yml
+++ b/roles/java/molecule/default/verify.yml
@@ -11,6 +11,7 @@
         PATH: "/home/testuser/.sdkman/candidates/java/current/bin:{{ ansible_facts['env']['PATH'] | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"
       register: java_version_output
       changed_when: false
+      failed_when: false
 
     - name: Assert Temurin is installed
       ansible.builtin.assert:

--- a/roles/java/molecule/default/verify.yml
+++ b/roles/java/molecule/default/verify.yml
@@ -1,0 +1,20 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    - name: Run java -version as testuser
+      ansible.builtin.command: java -version
+      become_user: testuser
+      environment:
+        PATH: "/home/testuser/.sdkman/candidates/java/current/bin:{{ ansible_env.PATH | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"
+      register: java_version_output
+      changed_when: false
+
+    - name: Assert Temurin is installed
+      ansible.builtin.assert:
+        that:
+          - "'Temurin' in java_version_output.stderr or 'Temurin' in java_version_output.stdout"
+        fail_msg: "Expected 'Temurin' in java -version output but got: {{ java_version_output.stderr }}"
+        success_msg: "Temurin JDK confirmed: {{ java_version_output.stderr }}"

--- a/roles/java/molecule/default/verify.yml
+++ b/roles/java/molecule/default/verify.yml
@@ -8,7 +8,7 @@
       ansible.builtin.command: java -version
       become_user: testuser
       environment:
-        PATH: "/home/testuser/.sdkman/candidates/java/current/bin:{{ ansible_env.PATH | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"
+        PATH: "/home/testuser/.sdkman/candidates/java/current/bin:{{ ansible_facts['env']['PATH'] | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"
       register: java_version_output
       changed_when: false
 

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -1,5 +1,14 @@
 #SPDX-License-Identifier: MIT-0
 ---
+- name: Install sdkman prerequisites
+  ansible.builtin.apt:
+    name:
+      - zip
+      - unzip
+      - curl
+    state: present
+    update_cache: false
+
 - name: Download sdkman installer
   ansible.builtin.get_url:
     url: "https://get.sdkman.io"

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -7,7 +7,7 @@
       - unzip
       - curl
     state: present
-    update_cache: false
+    update_cache: true
 
 - name: Download sdkman installer
   ansible.builtin.get_url:

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -25,11 +25,6 @@
   become_user: "{{ item }}"
   loop: "{{ desktop_user_names }}"
 
-- name: Remove sdkman installer
-  ansible.builtin.file:
-    path: /tmp/sdkman-install.sh
-    state: absent
-
 - name: Install Temurin JDK per user
   ansible.builtin.shell:
     cmd: >

--- a/roles/podman/DESIGN.md
+++ b/roles/podman/DESIGN.md
@@ -1,0 +1,60 @@
+# Design Notes: podman role
+
+This document records non-obvious design decisions made during implementation
+of the `podman` role. Decision numbers correspond to entries in
+`specs/006-podman-rootless-role/research.md`; only non-obvious decisions are
+recorded here, so gaps in numbering are intentional.
+
+## Decision 2 — lineinfile idempotency strategy for subuid/subgid
+
+`ansible.builtin.lineinfile` with `regexp: "^{{ item }}:"` is used to manage
+entries in `/etc/subuid` and `/etc/subgid`.
+
+The start-anchored regexp matches the existing line if it is already present
+(no change) or inserts the configured line if it is absent (change). This
+makes the task idempotent across playbook re-runs.
+
+`ansible.builtin.user` does not support subuid/subgid parameters in any
+released Ansible version (as of April 2026). `usermod --add-subuids` is not
+idempotent — it appends duplicate entries on every run. `lineinfile` is the
+correct tool here.
+
+## Decision 3 — `podman system migrate` `changed_when: false` guard
+
+`ansible.builtin.command: podman system migrate` runs as each desktop user
+after subuid/subgid changes. The task is marked `changed_when: false` because
+the command produces no reliable sentinel that could be used with `creates:`.
+
+Running it unconditionally is safe: on an already-migrated system it is a
+no-op at the storage level. Its cost is negligible. The `changed_when: false`
+guard prevents spurious "changed" reports on idempotency re-runs.
+
+A handler was not used. Handlers fire only when a notifying task reports
+`changed`, which would suppress the migration on idempotency re-runs where
+subuid/subgid lines are already correct. More importantly, introducing a
+`handlers/` directory for a single side-effect-free command adds structural
+complexity with no benefit — the unconditional approach is simpler and equally
+correct.
+
+## Decision 4 — Shared subuid/subgid start value for all users
+
+All users listed in `desktop_user_names` receive the same default
+`podman_subuid_start` / `podman_subgid_start` value (`100000`). This is
+intentional for the primary use case: a single-person workstation where only
+one user requires rootless Podman at a time. Overlapping subordinate ID ranges
+cause no problems when only one user's containers run concurrently.
+
+Per-user offset calculation is out of scope (YAGNI). Callers deploying to
+multi-user servers where non-overlapping ranges are required must override
+`podman_subuid_start` and `podman_subgid_start` per user via `host_vars` or
+`group_vars`.
+
+## Decision 5 — Play-level `become` convention
+
+No task in `tasks/main.yml` sets `become: true` at task level. The calling
+playbook sets `become: true` at play level, which is inherited by all tasks.
+Per-user tasks use `become_user: "{{ item }}"` to override the effective user
+without requiring explicit `become: true` on each task.
+
+This matches the convention established in `roles/java/`,
+`roles/android_studio/`, and `roles/flutter/`.

--- a/roles/podman/DESIGN.md
+++ b/roles/podman/DESIGN.md
@@ -19,7 +19,18 @@ released Ansible version (as of April 2026). `usermod --add-subuids` is not
 idempotent — it appends duplicate entries on every run. `lineinfile` is the
 correct tool here.
 
-## Decision 3 — `podman system migrate` `changed_when: false` guard
+## Decision 3 - Avoid `podman system migrate` in Molecule tests
+
+Molecule tests install the role under test into a podman container. When
+testing the podman role itself, this would run `podman system migrate` inside
+the container. Running podman inside podman would require nested virtualization
+which is not necessarily enabled on virtual machines.
+
+Thus we skip the `podman system migrate` step when running inside a container
+environment. The configuration variable `podman_run_migrate` is used to control
+this behavior.
+
+## Decision 4 — `podman system migrate` `changed_when: false` guard
 
 `ansible.builtin.command: podman system migrate` runs as each desktop user
 after subuid/subgid changes. The task is marked `changed_when: false` because
@@ -36,7 +47,7 @@ subuid/subgid lines are already correct. More importantly, introducing a
 complexity with no benefit — the unconditional approach is simpler and equally
 correct.
 
-## Decision 4 — Shared subuid/subgid start value for all users
+## Decision 5 — Shared subuid/subgid start value for all users
 
 All users listed in `desktop_user_names` receive the same default
 `podman_subuid_start` / `podman_subgid_start` value (`100000`). This is
@@ -49,7 +60,7 @@ multi-user servers where non-overlapping ranges are required must override
 `podman_subuid_start` and `podman_subgid_start` per user via `host_vars` or
 `group_vars`.
 
-## Decision 5 — Play-level `become` convention
+## Decision 6 — Play-level `become` convention
 
 No task in `tasks/main.yml` sets `become: true` at task level. The calling
 playbook sets `become: true` at play level, which is inherited by all tasks.

--- a/roles/podman/README.md
+++ b/roles/podman/README.md
@@ -1,0 +1,40 @@
+# Role: podman
+
+Installs Podman from the Ubuntu distribution repository and configures
+rootless container operation for every user listed in `desktop_user_names`.
+
+## Role Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `desktop_user_names` | `[]` | Users to configure for rootless Podman. Defaults to an empty list: Podman is installed system-wide but per-user rootless configuration is skipped. |
+| `podman_subuid_start` | `100000` | First UID in the subordinate UID range |
+| `podman_subuid_count` | `65536` | Number of UIDs in the subordinate UID range |
+| `podman_subgid_start` | `100000` | First GID in the subordinate GID range |
+| `podman_subgid_count` | `65536` | Number of GIDs in the subordinate GID range |
+
+## Example Playbook
+
+```yaml
+- name: Configure desktop
+  hosts: linux
+  become: true
+
+  vars:
+    desktop_user_names:
+      - alice
+      - bob
+
+  roles:
+    - podman
+```
+
+## Requirements
+
+- Ubuntu 22.04 LTS (Jammy) or later.
+- Ansible 2.19+.
+- The calling play must set `become: true` at play level.
+
+## Licence
+
+SPDX-License-Identifier: MIT-0

--- a/roles/podman/defaults/main.yml
+++ b/roles/podman/defaults/main.yml
@@ -5,3 +5,4 @@ podman_subuid_start: 100000
 podman_subuid_count: 65536
 podman_subgid_start: 100000
 podman_subgid_count: 65536
+podman_run_migrate: true

--- a/roles/podman/defaults/main.yml
+++ b/roles/podman/defaults/main.yml
@@ -1,0 +1,7 @@
+#SPDX-License-Identifier: MIT-0
+---
+desktop_user_names: []
+podman_subuid_start: 100000
+podman_subuid_count: 65536
+podman_subgid_start: 100000
+podman_subgid_count: 65536

--- a/roles/podman/meta/main.yml
+++ b/roles/podman/meta/main.yml
@@ -1,6 +1,8 @@
 #SPDX-License-Identifier: MIT-0
 galaxy_info:
   author: Stefan Boos
+  namespace: wonderbird
+  role_name: podman
   description: Install and configure rootless Podman on Ubuntu
   company: n.a.
   issue_tracker_url: https://github.com/wonderbird/ansible-all-my-things/issues

--- a/roles/podman/meta/main.yml
+++ b/roles/podman/meta/main.yml
@@ -1,0 +1,16 @@
+#SPDX-License-Identifier: MIT-0
+galaxy_info:
+  author: Stefan Boos
+  description: Install and configure rootless Podman on Ubuntu
+  company: n.a.
+  issue_tracker_url: https://github.com/wonderbird/ansible-all-my-things/issues
+  license: MIT-0
+  min_ansible_version: 2.19
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags: []
+
+dependencies: []

--- a/roles/podman/molecule/default/converge.yml
+++ b/roles/podman/molecule/default/converge.yml
@@ -1,0 +1,11 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    desktop_user_names:
+      - testuser
+  roles:
+    - role: podman
+      podman_run_migrate: false

--- a/roles/podman/molecule/default/molecule.yml
+++ b/roles/podman/molecule/default/molecule.yml
@@ -1,0 +1,26 @@
+#SPDX-License-Identifier: MIT-0
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: docker.io/library/ubuntu:24.04
+    pre_build_image: true
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/roles/podman/molecule/default/prepare.yml
+++ b/roles/podman/molecule/default/prepare.yml
@@ -6,12 +6,14 @@
   become: true
   tasks:
     - name: Update apt cache
-      ansible.builtin.raw: apt-get update -qq
+      ansible.builtin.raw: apt-get update
+      # become: false — sudo is not yet installed; run directly as root
       become: false
       changed_when: true
 
     - name: Install python3 and sudo
       ansible.builtin.raw: apt-get install -y -qq python3 sudo
+      # become: false — sudo is not yet installed; run directly as root
       become: false
       changed_when: true
 

--- a/roles/podman/molecule/default/prepare.yml
+++ b/roles/podman/molecule/default/prepare.yml
@@ -1,0 +1,22 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Prepare container
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.raw: apt-get update -qq
+      become: false
+      changed_when: true
+
+    - name: Install python3 and sudo
+      ansible.builtin.raw: apt-get install -y -qq python3 sudo
+      become: false
+      changed_when: true
+
+    - name: Create testuser
+      ansible.builtin.user:
+        name: testuser
+        state: present
+        create_home: true

--- a/roles/podman/molecule/default/verify.yml
+++ b/roles/podman/molecule/default/verify.yml
@@ -1,0 +1,45 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    - name: Run podman -version as testuser
+      ansible.builtin.command: podman --version
+      become_user: testuser
+      register: podman_version_output
+      changed_when: false
+      failed_when: false
+
+    - name: Assert podman is installed
+      ansible.builtin.assert:
+        that:
+          - "'podman' in podman_version_output.stdout"
+        fail_msg: "Expected 'podman' in podman --version output but got: {{ podman_version_output.stdout }}"
+        success_msg: "Podman confirmed: {{ podman_version_output.stdout }}"
+
+    - name: Read subuid configuration for testuser
+      ansible.builtin.command: grep "^testuser:" /etc/subuid
+      register: subuid_output
+      changed_when: false
+      failed_when: false
+
+    - name: Assert subuid output for testuser
+      ansible.builtin.assert:
+        that:
+          - "'testuser' in subuid_output.stdout"
+        fail_msg: "Expected 'testuser' in /etc/subuid output but got: {{ subuid_output.stdout }}"
+        success_msg: "Subuid confirmed for testuser: {{ subuid_output.stdout }}"
+
+    - name: Read subgid configuration for testuser
+      ansible.builtin.command: grep "^testuser:" /etc/subgid
+      register: subgid_output
+      changed_when: false
+      failed_when: false
+
+    - name: Assert subgid output for testuser
+      ansible.builtin.assert:
+        that:
+          - "'testuser' in subgid_output.stdout"
+        fail_msg: "Expected 'testuser' in /etc/subgid output but got: {{ subgid_output.stdout }}"
+        success_msg: "Subgid confirmed for testuser: {{ subgid_output.stdout }}"

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -23,4 +23,5 @@
   ansible.builtin.command: podman system migrate
   become_user: "{{ item }}"
   loop: "{{ desktop_user_names }}"
+  when: podman_run_migrate
   changed_when: false

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -4,6 +4,7 @@
   ansible.builtin.apt:
     name: podman
     state: present
+    update_cache: true
 
 - name: Configure subuid for each desktop user
   ansible.builtin.lineinfile:

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -1,0 +1,26 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Install Podman
+  ansible.builtin.apt:
+    name: podman
+    state: present
+
+- name: Configure subuid for each desktop user
+  ansible.builtin.lineinfile:
+    path: /etc/subuid
+    regexp: "^{{ item }}:"
+    line: "{{ item }}:{{ podman_subuid_start }}:{{ podman_subuid_count }}"
+  loop: "{{ desktop_user_names }}"
+
+- name: Configure subgid for each desktop user
+  ansible.builtin.lineinfile:
+    path: /etc/subgid
+    regexp: "^{{ item }}:"
+    line: "{{ item }}:{{ podman_subgid_start }}:{{ podman_subgid_count }}"
+  loop: "{{ desktop_user_names }}"
+
+- name: Run podman system migrate for each desktop user
+  ansible.builtin.command: podman system migrate
+  become_user: "{{ item }}"
+  loop: "{{ desktop_user_names }}"
+  changed_when: false

--- a/scripts/test-molecule-all.sh
+++ b/scripts/test-molecule-all.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT-0
+#
+# Run `molecule test` for every role that has a
+# molecule/default/molecule.yml scenario. Roles without a scenario
+# (e.g. desktop, Windows) are skipped.
+#
+# All roles are tested even if one fails. A summary is printed at the end.
+#
+# Usage: run from the project root
+#   ./scripts/test-molecule-all.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+passed=()
+failed=()
+
+for role in "${PROJECT_ROOT}"/roles/*/; do
+  if [ -f "${role}molecule/default/molecule.yml" ]; then
+    name="$(basename "${role}")"
+    echo "==> Testing ${name}"
+    if (cd "${role}" && molecule test); then
+      passed+=("${name}")
+    else
+      failed+=("${name}")
+    fi
+  fi
+done
+
+echo ""
+echo "Results: ${#passed[@]} passed, ${#failed[@]} failed"
+
+if [ ${#passed[@]} -gt 0 ]; then
+  for name in "${passed[@]}"; do
+    echo "  PASS  ${name}"
+  done
+fi
+
+if [ ${#failed[@]} -gt 0 ]; then
+  for name in "${failed[@]}"; do
+    echo "  FAIL  ${name}"
+  done
+  exit 1
+fi

--- a/specs/005-java-role/plan.md
+++ b/specs/005-java-role/plan.md
@@ -11,11 +11,14 @@
 ## Summary
 
 Install sdkman and the Temurin JDK (pinned LTS version) into the home directory
-of every user listed in `desktop_user_names`, using a three-task per-user
-sequence: download the sdkman installer, run the installer, then install the JDK
-via `sdk install java`. All tasks are guarded for idempotency with `creates:`.
+of every user listed in `desktop_user_names`, using a four-task per-user
+sequence: install prerequisites (`zip`, `unzip`, `curl`) via apt, download the
+sdkman installer, run the installer, then install the JDK via `sdk install java`.
+All tasks are guarded for idempotency with `creates:`.
 The role follows the conventions of the `android_studio` and `flutter` reference
 roles (SPDX header, FQCN, `become_user`, no task-level `become`).
+A Molecule test scenario (driver: `podman`, platform: `ubuntu:24.04`) provides
+automated acceptance verification.
 
 ## Technical Context
 
@@ -24,7 +27,8 @@ roles (SPDX header, FQCN, `become_user`, no task-level `become`).
 `https://get.sdkman.io`; Eclipse Temurin JDK published on sdkman as `tem` vendor
 **Storage**: Per-user `~/.sdkman/` directory tree on the remote host; no
 controller-side storage
-**Testing**: Manual Vagrant run per `CONTRIBUTING.md` (no Molecule); SC-005
+**Testing**: `molecule test` inside `roles/java/` using `molecule-plugins[podman]`
+and `ubuntu:24.04`; SC-005
 **Target Platform**: AMD64 + ARM64 Ubuntu Linux (both supported by sdkman and
 Temurin)
 **Project Type**: Ansible role
@@ -32,7 +36,8 @@ Temurin)
 **Constraints**: Idempotent (zero `changed` on second run); no task-level
 `become`; FQCN throughout; SPDX header on every YAML file; no system-wide Java
 installation
-**Scale/Scope**: One role; three tasks per user; one variable; one DESIGN.md
+**Scale/Scope**: One role; four tasks per user (apt prerequisites + three
+sdkman/JDK steps); one variable; one DESIGN.md; one Molecule scenario
 
 ## Constitution Check
 
@@ -42,7 +47,7 @@ installation
 | --------- | ------ | ----- |
 | I. Idempotency | PASS | All `shell`/`command` tasks use `creates:` guards referencing version-specific paths. |
 | II. Role-First | PASS | Implemented as `roles/java/`; no implementation logic in playbooks. |
-| III. Test Locally Before Cloud | PASS | Vagrant test is the acceptance criterion (SC-005); role isolated in `configure-linux-roles.yml`. |
+| III. Test Locally Before Cloud | PASS | Molecule + Podman (`molecule test`) is the acceptance criterion (SC-005); this satisfies local-VM validation without cloud access. |
 | IV. Simplicity (YAGNI) | PASS | Three tasks per user, one variable, no speculative abstraction. |
 | V. Conventional Commits | PASS | No commits in this plan phase; will follow `feat:` prefix on first implementation commit. |
 | VI. Markdown Quality | PASS | All `.md` files produced here follow ATX headings and blank-line list rules. |
@@ -74,12 +79,18 @@ variable defined by the calling playbook/inventory; those are documented in
 ```text
 roles/java/
 ├── defaults/
-│   └── main.yml           # java_sdkman_identifier default value
+│   └── main.yml               # java_sdkman_identifier default value
 ├── meta/
-│   └── main.yml           # galaxy_info
+│   └── main.yml               # galaxy_info
+├── molecule/
+│   └── default/
+│       ├── molecule.yml       # podman driver, ubuntu:24.04 platform
+│       ├── prepare.yml        # install python3+sudo, create testuser
+│       ├── converge.yml       # apply java role with testuser
+│       └── verify.yml         # assert java -version contains Temurin
 ├── tasks/
-│   └── main.yml           # All provisioning tasks
-└── DESIGN.md              # Non-obvious design decisions
+│   └── main.yml               # All provisioning tasks
+└── DESIGN.md                  # Non-obvious design decisions
 ```
 
 **Structure Decision**: Single-role layout matching every other role in the

--- a/specs/005-java-role/spec.md
+++ b/specs/005-java-role/spec.md
@@ -134,6 +134,24 @@ and selectable.
 - **FR-011**: The role MUST include a `meta/main.yml` with `galaxy_info`.
 - **FR-012**: The role MUST include a `DESIGN.md` documenting non-obvious design
   decisions.
+- **FR-013**: The role MUST install the packages `zip`, `unzip`, and `curl` via
+  `ansible.builtin.apt` as the very first task in `tasks/main.yml`, before any
+  sdkman installation steps. These packages are required by the sdkman installer.
+- **FR-014**: The role MUST include a Molecule test scenario under
+  `roles/java/molecule/default/` using the `podman` driver (via
+  `molecule-plugins[podman]`).
+- **FR-015**: The Molecule scenario MUST use `ubuntu:24.04` as the container
+  image platform.
+- **FR-016**: The Molecule scenario MUST include a `prepare.yml` playbook that
+  installs `python3` and `sudo` inside the container before the converge phase
+  runs (Ansible requires both to execute tasks).
+- **FR-017**: The Molecule `prepare.yml` MUST create a system user named
+  `testuser` inside the container, and the Molecule `converge.yml` MUST pass
+  `desktop_user_names: ["testuser"]` to the role.
+- **FR-018**: The Molecule scenario MUST enable the built-in idempotency
+  verifier step (second converge run that asserts zero `changed` tasks).
+- **FR-019**: The Molecule scenario MUST include a `verify.yml` playbook that
+  runs `java -version` as `testuser` and asserts the output contains "Temurin".
 
 ### Key Entities
 
@@ -166,9 +184,10 @@ and selectable.
   ARM64 Ubuntu Linux test VMs.
 - **SC-004**: The installed JDK version matches the value of
   `java_sdkman_identifier` defined in `defaults/main.yml`.
-- **SC-005**: The role can be exercised in isolation (only the `java` role
-  active in the playbook) against a local Vagrant/Docker VM following the
-  procedure in `CONTRIBUTING.md`.
+- **SC-005**: Running `molecule test` inside `roles/java/` succeeds: the
+  converge phase installs Java without errors, the idempotency step reports
+  zero `changed` tasks, and the verify step confirms `java -version` output
+  contains "Temurin" for `testuser`.
 
 ## Assumptions
 
@@ -192,8 +211,9 @@ and selectable.
   directories.
 - Internet access is available during provisioning; no offline/air-gapped
   support is in scope.
-- No Molecule test suite is required. SC-005 is satisfied by a successful
-  manual Vagrant run following the procedure in `CONTRIBUTING.md`.
+- A Molecule test suite (`molecule-plugins[podman]`) is the primary automated
+  acceptance mechanism for this role. `molecule test` MUST pass before the
+  branch is merged.
 - Standard Ansible output and verbosity apply to all tasks. No task in this
   role requires `no_log: true`; in particular, the sdkman init script source
   path does not contain sensitive data and MUST NOT suppress output.

--- a/specs/005-java-role/tasks.md
+++ b/specs/005-java-role/tasks.md
@@ -6,8 +6,8 @@
 **Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
 
 **Organization**: Tasks are grouped by user story to enable independent
-implementation and testing of each story. No test tasks are generated
-(not requested in the feature specification).
+implementation and testing of each story. Molecule test scaffold tasks
+(T017–T023) are added as Phase 7 to cover FR-013 through FR-019.
 
 ## Format: `[ID] [P?] [Story] Description`
 
@@ -59,6 +59,12 @@ in the output.
 
 ### Implementation — US1
 
+- [x] T017 [US1] Add prerequisites task as the **first** task in
+  `roles/java/tasks/main.yml`: `ansible.builtin.apt` installing
+  `zip`, `unzip`, and `curl` with `state: present` and
+  `update_cache: false`. These packages are required by the sdkman
+  installer. Place this task before the `Download sdkman installer`
+  task (FR-013).
 - [x] T005 [US1] Write `roles/java/tasks/main.yml` with SPDX header and the
   download task: `ansible.builtin.get_url` fetching `https://get.sdkman.io`
   to `/tmp/sdkman-install.sh`. `get_url` is idempotent by default via
@@ -177,6 +183,38 @@ idempotency confirmation, and ARM64 validation.
 
 ---
 
+## Phase 7: Molecule Test Scenario (FR-013–FR-019, SC-005)
+
+**Purpose**: Create the Molecule test scaffold for automated acceptance
+testing of the `java` role using Podman as the container driver.
+
+- [x] T018 Create `roles/java/molecule/default/molecule.yml` with SPDX
+  header. Configure: driver `podman`, platform `ubuntu:24.04`, and rely
+  on the default `test_sequence` (which includes the `idempotency` step
+  automatically — no explicit `test_sequence` config required) (FR-014,
+  FR-015, FR-018).
+- [x] T019 Create `roles/java/molecule/default/prepare.yml`. Use
+  `ansible.builtin.raw` to run `apt-get update && apt-get install -y
+  python3 sudo` (the container has no Python yet; `raw` is the only
+  viable pre-Python step). Then use `ansible.builtin.user` to create
+  `testuser` with `state: present` and `create_home: true` (FR-016,
+  FR-017).
+- [x] T020 Create `roles/java/molecule/default/converge.yml` with SPDX
+  header. Apply the `java` role with `become: true` and pass
+  `desktop_user_names: ["testuser"]` as a role variable (FR-017).
+- [x] T021 Create `roles/java/molecule/default/verify.yml` with SPDX
+  header. Run `java -version 2>&1` as `testuser` using
+  `ansible.builtin.command` and register the output. Assert that the
+  output contains "Temurin" (FR-019).
+- [x] T022 Update `requirements.txt` to add `molecule` and
+  `molecule-plugins[podman]` as Python dependencies (FR-014, U3).
+- [ ] T023 **Acceptance test**: Run `molecule test` inside `roles/java/`
+  and confirm: converge completes without errors, idempotency step
+  reports zero `changed` tasks, verify step passes. This is SC-005
+  (replaces the manual Vagrant acceptance run).
+
+---
+
 ## Dependencies and Execution Order
 
 ### Phase Dependencies
@@ -271,8 +309,8 @@ All four are independent — launch together.
 
 ## Notes
 
-- No test tasks are generated — the spec does not request TDD or automated
-  tests; SC-005 is satisfied by a manual Vagrant run per `CONTRIBUTING.md`.
+- Molecule test tasks (T017–T023) cover FR-013 through FR-019; SC-005 is
+  satisfied by a successful `molecule test` run inside `roles/java/`.
 - All per-user tasks use `loop: "{{ desktop_user_names }}"` and
   `become_user: "{{ item }}"`. The download task (T005) does NOT use
   `become_user` because it writes to `/tmp` as root (play-level

--- a/specs/006-podman-rootless-role/checklists/requirements.md
+++ b/specs/006-podman-rootless-role/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Rootless Podman Ansible Role
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. The specification is ready for `/speckit.plan`.

--- a/specs/006-podman-rootless-role/data-model.md
+++ b/specs/006-podman-rootless-role/data-model.md
@@ -1,0 +1,60 @@
+# Data Model: Rootless Podman Ansible Role
+
+**Feature**: `006-podman-rootless-role`
+**Date**: 2026-04-11
+
+## Role Variables
+
+These are the entities (variables) the role operates on. All defaults are
+declared in `roles/podman/defaults/main.yml`.
+
+### Input Variables
+
+| Variable | Type | Default | Source | Description |
+| --- | --- | --- | --- | --- |
+| `desktop_user_names` | list of strings | (none — caller must supply) | playbook `vars:` | Usernames of all desktop users to configure for rootless Podman. Defined by the calling playbook as `"{{ desktop_users \| map(attribute='name') \| list }}"`. |
+| `podman_subuid_start` | integer | `100000` | `defaults/main.yml` | First sub-UID in the range allocated to each desktop user. |
+| `podman_subuid_count` | integer | `65536` | `defaults/main.yml` | Number of sub-UIDs allocated to each desktop user. |
+| `podman_subgid_start` | integer | `100000` | `defaults/main.yml` | First sub-GID in the range allocated to each desktop user. |
+| `podman_subgid_count` | integer | `65536` | `defaults/main.yml` | Number of sub-GIDs allocated to each desktop user. |
+
+### Validation Rules
+
+- `desktop_user_names` MUST be defined by the caller. An empty list (`[]`) is
+  valid: the install task runs but per-user loops are skipped.
+- Each entry in `desktop_user_names` MUST correspond to an existing system
+  user. The role does not create users (out of scope).
+- `podman_subuid_start` and `podman_subuid_count` MUST be positive integers.
+  No runtime validation is added (YAGNI for a single-person project).
+
+## System File Entities
+
+These are the files the role reads from or writes to on the target host.
+
+| File | Module | Operation | Idempotency Mechanism |
+| --- | --- | --- | --- |
+| `/etc/subuid` | `ansible.builtin.lineinfile` | Ensure line `username:start:count` present | `regexp: '^{{ item }}:'` matches existing line; no duplicate created |
+| `/etc/subgid` | `ansible.builtin.lineinfile` | Ensure line `username:start:count` present | `regexp: '^{{ item }}:'` matches existing line; no duplicate created |
+
+## Task Flow
+
+```text
+1. Install podman (apt)
+   └─ ansible.builtin.apt: name=podman state=present
+
+2. For each user in desktop_user_names:
+   ├─ Ensure subuid entry (lineinfile on /etc/subuid)
+   ├─ Ensure subgid entry (lineinfile on /etc/subgid)
+   └─ Run podman system migrate (command, become_user=item, changed_when=false)
+```
+
+## State Transitions
+
+| System State Before | Task | System State After |
+| --- | --- | --- |
+| Podman not installed | apt install podman | Podman binary present at `/usr/bin/podman` |
+| No subuid entry for user | lineinfile /etc/subuid | Entry `user:100000:65536` present |
+| No subgid entry for user | lineinfile /etc/subgid | Entry `user:100000:65536` present |
+| subuid/subgid entries exist | lineinfile (regexp matches) | No change; file unchanged |
+| User namespace mapping stale | podman system migrate | Mapping updated; `changed_when: false` |
+| All already configured | all tasks | All tasks report `ok`; zero `changed` |

--- a/specs/006-podman-rootless-role/plan.md
+++ b/specs/006-podman-rootless-role/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Rootless Podman Ansible Role
+
+**Branch**: `006-podman-rootless-role` | **Date**: 2026-04-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/006-podman-rootless-role/spec.md`
+
+## Summary
+
+Create `roles/podman/` — an Ansible role that installs Podman from the Ubuntu
+apt repository and configures rootless container operation for every user in
+`desktop_user_names` by managing `/etc/subuid` and `/etc/subgid` with
+`ansible.builtin.lineinfile`, then running `podman system migrate` per user
+so the new user-namespace mapping takes effect immediately.
+
+## Technical Context
+
+**Language/Version**: YAML — Ansible 2.19+
+
+**Primary Dependencies**: `ansible.builtin.*` (no Galaxy collections needed);
+Ubuntu `podman` apt package
+
+**Storage**: `/etc/subuid`, `/etc/subgid` (system files managed by
+`lineinfile`)
+
+**Testing**: Local Vagrant + Docker VM (Linux AMD64);
+`configure-linux-roles.yml` with only the `podman` role active
+
+**Target Platform**: Ubuntu Linux 22.04 LTS and later (AMD64 and ARM64)
+
+**Project Type**: Ansible role (infrastructure automation)
+
+**Performance Goals**: N/A — provisioning tool, not a service
+
+**Constraints**: Zero changed tasks on second run (idempotency); no external
+PPA; no docker shim; no systemd lingering; no registries.conf changes
+
+**Scale/Scope**: Per-user loop over `desktop_user_names`; single role, ~5 tasks
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+| --- | --- | --- |
+| I. Idempotency | PASS | `apt` module is idempotent; `lineinfile` with `regexp: ^username:` is idempotent; `podman system migrate` is guarded with `changed_when: false` so the task always reports `ok` (never `changed`), making it safe to re-run |
+| II. Role-First Organisation | PASS | New capability implemented as a standalone role in `roles/podman/` |
+| III. Test Locally Before Cloud | PASS (reminder) | Must be validated on local VM before any cloud target |
+| IV. Simplicity (YAGNI) | PASS | No docker shim, no lingering, no registries.conf, no pre-flight version assert |
+| V. Conventional Commits | PASS (reminder) | Commits must use `feat:` prefix for role creation |
+| VI. Markdown Quality Standards | PASS (reminder) | README.md and DESIGN.md must comply; `format-markdown` skill applied after creation |
+
+No constitution violations. Complexity Tracking table is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-podman-rootless-role/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command — NOT created by /speckit.plan)
+```
+
+No `contracts/` directory is generated. This role exposes no external APIs,
+endpoints, or CLI schemas; it is purely an internal infrastructure automation
+artifact.
+
+### Source Code (repository root)
+
+```text
+roles/podman/
+├── defaults/
+│   └── main.yml          # subuid_start, subuid_count, subgid_start, subgid_count
+├── meta/
+│   └── main.yml          # galaxy_info: author, description, platforms, license
+├── tasks/
+│   └── main.yml          # install + per-user subuid/subgid + podman system migrate
+├── README.md             # purpose, variables table, example playbook, license
+└── DESIGN.md             # non-obvious design decisions (lineinfile strategy, migrate guard)
+```
+
+**Structure Decision**: Single-role layout matching the established convention
+in `roles/java/`, `roles/android_studio/`, and `roles/flutter/`. No handlers
+directory (no service restart needed). No templates directory (no Jinja2
+templates needed). No files directory.
+
+## Complexity Tracking
+
+No constitution violations requiring justification.

--- a/specs/006-podman-rootless-role/quickstart.md
+++ b/specs/006-podman-rootless-role/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart: Rootless Podman Ansible Role
+
+**Feature**: `006-podman-rootless-role`
+**Date**: 2026-04-11
+
+## Prerequisites
+
+- Ubuntu 22.04 LTS or later target host (AMD64 or ARM64).
+- Ansible 2.19+ on the control node.
+- SSH access to the target with sudo privileges.
+- `desktop_user_names` list populated (via the playbook `vars:` block or
+  inventory).
+
+## Local Test (Vagrant + Docker VM)
+
+Follow the standard CONTRIBUTING.md procedure:
+
+1. Edit `configure-linux-roles.yml` and set the `roles:` list to only
+   `podman` (comment out all other roles).
+2. Run the playbook against the local VM:
+
+   ```bash
+   ansible-playbook configure-linux-roles.yml -i inventories/local
+   ```
+
+3. Verify idempotency — run again and confirm zero changed tasks:
+
+   ```bash
+   ansible-playbook configure-linux-roles.yml -i inventories/local
+   ```
+
+4. Log in as one of the target users and verify rootless Podman works:
+
+   ```bash
+   podman --version
+   podman run --rm hello-world
+   ```
+
+## Adding the Role to configure-linux-roles.yml
+
+Once local testing passes, add `podman` to the `roles:` list in
+`configure-linux-roles.yml`:
+
+```yaml
+roles:
+  - podman
+  - claude_code
+  # ... other roles
+```
+
+## Role Variables Reference
+
+| Variable | Default | Override in |
+| --- | --- | --- |
+| `podman_subuid_start` | `100000` | `group_vars/`, `host_vars/`, or playbook `vars:` |
+| `podman_subuid_count` | `65536` | same |
+| `podman_subgid_start` | `100000` | same |
+| `podman_subgid_count` | `65536` | same |
+
+`desktop_user_names` has no default and must be supplied by the caller.
+
+## Acceptance Test Checklist
+
+- [ ] `podman --version` succeeds for every user in `desktop_user_names`.
+- [ ] `/etc/subuid` contains a valid entry for every user.
+- [ ] `/etc/subgid` contains a valid entry for every user.
+- [ ] `podman run --rm hello-world` succeeds as a listed user (rootless).
+- [ ] Second playbook run reports zero changed tasks.

--- a/specs/006-podman-rootless-role/quickstart.md
+++ b/specs/006-podman-rootless-role/quickstart.md
@@ -33,7 +33,8 @@ Follow the standard CONTRIBUTING.md procedure:
 
    ```bash
    podman --version
-   podman run --rm hello-world
+   podman build -t devcontainer .devcontainer/
+   podman run --rm devcontainer ansible --version
    ```
 
 ## Adding the Role to configure-linux-roles.yml
@@ -64,5 +65,6 @@ roles:
 - [ ] `podman --version` succeeds for every user in `desktop_user_names`.
 - [ ] `/etc/subuid` contains a valid entry for every user.
 - [ ] `/etc/subgid` contains a valid entry for every user.
-- [ ] `podman run --rm hello-world` succeeds as a listed user (rootless).
+- [ ] `podman build -t devcontainer .devcontainer/` succeeds as a listed user.
+- [ ] `podman run --rm devcontainer ansible --version` prints a version string.
 - [ ] Second playbook run reports zero changed tasks.

--- a/specs/006-podman-rootless-role/research.md
+++ b/specs/006-podman-rootless-role/research.md
@@ -1,0 +1,131 @@
+# Research: Rootless Podman Ansible Role
+
+**Feature**: `006-podman-rootless-role`
+**Date**: 2026-04-11
+
+## Summary
+
+All technical questions were resolved from codebase inspection, Ubuntu package
+documentation, and Podman upstream documentation. No external unknowns remain.
+
+---
+
+## Decision 1 — Package source for Podman
+
+**Decision**: Install from the Ubuntu distribution repository using
+`ansible.builtin.apt` with `name: podman` and `state: present`.
+
+**Rationale**: The Ubuntu 22.04 LTS (Jammy) and later repositories include the
+`podman` package. No external PPA is required. Using the distribution package
+keeps the role offline-capable after initial APT cache population and avoids
+third-party GPG key management. FR-001 and the spec assumption both confirm
+this choice.
+
+**Alternatives considered**:
+
+- Kubic OBS PPA (newer Podman versions): rejected — adds PPA management
+  complexity with no confirmed benefit for this project (YAGNI).
+- Building from source: rejected — out of scope, unnecessary complexity.
+
+---
+
+## Decision 2 — subuid/subgid management strategy
+
+**Decision**: Use `ansible.builtin.lineinfile` with `regexp: '^{{ item }}:'`
+and `line: '{{ item }}:{{ podman_subuid_start }}:{{ podman_subuid_count }}'`
+on both `/etc/subuid` and `/etc/subgid`, looping over `desktop_user_names`.
+
+**Rationale**: `ansible.builtin.lineinfile` with a start-anchored regexp is
+idempotent: it matches the existing line if present (no change) or inserts the
+configured line if absent (change). The spec explicitly documents this approach
+in its Assumptions section and justifies why `ansible.builtin.user` and
+`usermod --add-subuids` are not used:
+
+- `ansible.builtin.user` has no subuid/subgid parameter in any released Ansible
+  version as of April 2026.
+- `usermod --add-subuids` is not idempotent — it appends duplicates on
+  re-runs.
+
+**Alternatives considered**:
+
+- `community.general.user` with subuid support: not available in any released
+  version.
+- `ansible.builtin.command: usermod --add-subuids`: not idempotent, rejected.
+- `ansible.builtin.template` for full file management: over-engineered for a
+  single-entry-per-user pattern; lineinfile is sufficient (YAGNI).
+
+---
+
+## Decision 3 — podman system migrate idempotency guard
+
+**Decision**: Use `ansible.builtin.command` with `changed_when: false` to run
+`podman system migrate` as each user after subuid/subgid changes.
+
+**Rationale**: `podman system migrate` is a safe, fast, non-destructive command
+that re-applies the user-namespace mapping from `/etc/subuid` and `/etc/subgid`
+to the user's local container storage. It produces no reliable sentinel file to
+use with `creates:`. Marking it `changed_when: false` satisfies FR-006 and
+Principle I by preventing spurious "changed" reports. The command is always
+executed but is idempotent in effect — running it on an already-migrated system
+is a no-op at the storage level.
+
+**Alternatives considered**:
+
+- Triggering migrate via a handler notified by the lineinfile tasks: would
+  prevent migrate from running on the first play run if subuid/subgid lines
+  are not yet present. Running unconditionally is simpler and correct.
+- Using `creates:` with a sentinel file: no reliable sentinel exists for
+  migration state; this would require writing a marker file, adding
+  unnecessary complexity.
+
+---
+
+## Decision 4 — Default subuid/subgid ranges
+
+**Decision**: `podman_subuid_start: 100000`, `podman_subuid_count: 65536`. Identical
+defaults for `podman_subgid_start` and `podman_subgid_count`.
+
+**Rationale**: These are the standard defaults used by `useradd` on modern
+Ubuntu systems (documented in `/etc/login.defs`). 65536 sub-IDs is the
+minimum required for containers that map up to 65535 UIDs. Using the same
+start for all users is a conscious simplification: this role targets a
+workstation with a small, known set of desktop users, not a multi-tenant server
+where ranges must be non-overlapping (YAGNI / Principle IV).
+
+**Alternatives considered**:
+
+- Per-user calculated offsets (e.g. `100000 + user_index * 65536`): adds
+  complexity; not needed for a single-person workstation.
+- Larger count (e.g. 131072): unnecessary; 65536 covers all practical rootless
+  container use cases.
+
+---
+
+## Decision 5 — No task-level `become: true`
+
+**Decision**: No task in `tasks/main.yml` sets `become: true` at task level.
+The calling playbook `configure-linux-roles.yml` sets `become: true` at play
+level. Per-user tasks use `become_user: "{{ item }}"`.
+
+**Rationale**: Matches the established convention in `roles/java/`,
+`roles/android_studio/`, and `roles/flutter/`. Play-level `become` is
+inherited by all tasks. `become_user` overrides the effective user for
+specific tasks without requiring explicit `become: true` on each.
+
+---
+
+## Decision 6 — ARM64 compatibility
+
+**Decision**: No architecture-specific branching; no `not-supported-on-vagrant-arm64`
+tag in `configure-linux-roles.yml`.
+
+**Rationale**: The Ubuntu `podman` package is available for both `amd64` and
+`arm64`. APT resolves the correct architecture automatically. Rootless
+configuration via `/etc/subuid` and `/etc/subgid` is architecture-independent.
+`podman system migrate` is also architecture-independent.
+
+---
+
+## No NEEDS CLARIFICATION items remaining
+
+All technical questions are resolved. The plan and design can proceed to Phase 1.

--- a/specs/006-podman-rootless-role/spec.md
+++ b/specs/006-podman-rootless-role/spec.md
@@ -1,0 +1,205 @@
+# Feature Specification: Rootless Podman Ansible Role
+
+**Feature Branch**: `006-podman-rootless-role`
+**Created**: 2026-04-11
+**Status**: Draft
+**Input**: User description: "Create a new Ansible role called podman inside
+the roles/ directory. Install Podman in rootless mode on Ubuntu Linux and
+configure it for every user listed in the desktop_user_names variable."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Install and Run Podman as a Desktop User (Priority: P1)
+
+A developer provisioning a new Ubuntu Linux workstation runs the Ansible playbook.
+After the run completes, every desktop user listed in the shared configuration
+variable can invoke `podman` from their own login shell, build a container image
+from the repository's Dockerfile, and run that image — without requiring root
+privileges.
+
+**Why this priority**: This is the single primary outcome the role exists to
+deliver. All other stories depend on this working first.
+
+**Independent Test**: Run the playbook against a fresh Ubuntu VM, then log in
+as one of the target users and run `podman --version`. A version string proves
+the tool is present and accessible. Run `podman build` and `podman run` to
+confirm end-to-end container workflows work.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh Ubuntu VM with no Podman installed, **When** the playbook
+   is run with a populated `desktop_user_names` list, **Then** `podman --version`
+   succeeds for every listed user.
+
+2. **Given** Podman is installed for all listed users, **When** a user runs
+   `podman build -t devcontainer -f .devcontainer/Dockerfile .` from the
+   repository root, **Then** the build completes without errors.
+
+3. **Given** a container image named `devcontainer` exists in the user's local
+   registry, **When** the user runs `podman run --rm devcontainer ansible --version`,
+   **Then** an Ansible version string is printed to stdout.
+
+---
+
+### User Story 2 - Rootless Configuration Per User (Priority: P2)
+
+A system administrator needs every listed desktop user to be able to run
+containers without root access. The role automatically configures the
+kernel-level user-namespace mappings required for rootless container operation.
+
+**Why this priority**: Without correct subuid/subgid entries, rootless Podman
+cannot run containers. This is a hard prerequisite for user story 1 to work
+reliably across all users, but it is a distinct configuration concern.
+
+**Independent Test**: After the role runs, inspect `/etc/subuid` and `/etc/subgid`.
+Each user in `desktop_user_names` must have a valid range entry. Then run
+`podman run --rm hello-world` as one of those users to confirm rootless
+operation works end-to-end.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user in `desktop_user_names` has no subuid/subgid entries,
+   **When** the playbook runs, **Then** valid subuid and subgid ranges are
+   present in `/etc/subuid` and `/etc/subgid` for that user.
+
+2. **Given** subuid/subgid entries already exist for a user, **When** the
+   playbook runs again, **Then** no duplicate entries are created and the
+   task reports no changes.
+
+---
+
+### User Story 3 - Idempotent Re-Runs (Priority: P3)
+
+A developer re-runs the playbook on a machine where Podman is already fully
+configured. The role must complete without making any changes, confirming the
+system is already in the desired state.
+
+**Why this priority**: Idempotency is a non-negotiable constitutional
+requirement (Principle I). Failing this would make the role unsafe for repeated
+provisioning runs.
+
+**Independent Test**: Run the playbook twice in sequence. The second run must
+report zero changed tasks.
+
+**Acceptance Scenarios**:
+
+1. **Given** Podman is already installed and all users are fully configured,
+   **When** the playbook is run again, **Then** every task reports `ok` or
+   `skipped` and no task reports `changed`.
+
+---
+
+### Edge Cases
+
+- What happens when a username in `desktop_user_names` does not exist on the
+  target system? `ansible.builtin.lineinfile` does NOT fail for a non-existent
+  system user — it silently writes an orphaned entry to `/etc/subuid` and
+  `/etc/subgid`. The role does not validate whether the user exists in the
+  system (YAGNI); callers must ensure `desktop_user_names` contains valid
+  system users.
+
+- What happens when the Ubuntu apt package `podman` is already at the latest
+  version? The apt task must report no change (idempotent).
+
+- What happens when a user already has subuid/subgid entries from a prior
+  manual setup? The role must not create duplicate entries.
+
+- What happens when `desktop_user_names` is an empty list? The role must
+  install Podman system-wide but skip all per-user configuration loops without
+  error.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The role MUST install Podman from the Ubuntu distribution
+  package repository using the system package manager.
+
+- **FR-002**: The role MUST ensure that, for every user in `desktop_user_names`,
+  a valid subuid range entry exists in `/etc/subuid`.
+
+- **FR-003**: The role MUST ensure that, for every user in `desktop_user_names`,
+  a valid subgid range entry exists in `/etc/subgid`.
+
+- **FR-004**: Every task MUST be idempotent: re-running the role against an
+  already-configured host MUST produce zero changed tasks.
+
+- **FR-005**: The role MUST use `ansible.builtin.*` fully-qualified collection
+  names for every module used.
+
+- **FR-006**: Any `command` or `shell` task MUST include a `creates:` or
+  `changed_when:` guard to prevent unnecessary re-execution.
+
+- **FR-007**: The role MUST include a `defaults/main.yml` file that declares
+  all role variables with sensible defaults.
+
+- **FR-008**: The role MUST include a `meta/main.yml` file describing the
+  role's metadata (author, licence, platforms).
+
+- **FR-009**: Every YAML file in the role MUST carry the SPDX licence header
+  `# SPDX-License-Identifier: MIT-0` as its first line.
+
+- **FR-010**: The role MUST include a `README.md` documenting the role's
+  purpose, variables, and usage, following the project's Markdown quality
+  standards (Principle VI).
+
+- **FR-011**: The role MUST NOT install the `podman-docker` compatibility
+  shim; users invoke `podman` directly.
+
+- **FR-012**: The role MUST include a `DESIGN.md` file documenting non-obvious
+  design decisions (e.g. subuid/subgid allocation strategy, `podman system
+  migrate` guard choice).
+
+### Assumptions
+
+- The Ubuntu distribution package for `podman` (available in Ubuntu 22.04 LTS
+  and later) supports `--mount=type=cache` in `podman build`. No external PPA
+  is required.
+
+- The `# syntax=docker/dockerfile:1` comment in `.devcontainer/Dockerfile` is
+  a BuildKit parser directive that Podman ignores silently; no Podman-specific
+  Dockerfile modifications are needed.
+
+- Each username in `desktop_user_names` corresponds to an existing system user.
+  User creation is out of scope for this role.
+
+- subuid/subgid entries are managed with `ansible.builtin.lineinfile` targeting
+  `/etc/subuid` and `/etc/subgid` directly. The `regexp` is anchored to
+  `^username:` so each task matches and enforces the complete
+  `username:start:count` line — making the operation idempotent. Neither
+  `ansible.builtin.user` (no subuid/subgid support in any released Ansible
+  version) nor `usermod --add-subuids` (not idempotent) is used. Default role
+  variables: `subuid_start: 100000`, `subuid_count: 65536` (and identical
+  defaults for subgid).
+
+- Systemd lingering is not configured. The use case is interactive
+  `podman build` / `podman run`; no containers run as persistent services.
+  Enabling lingering would add complexity with no benefit (YAGNI).
+
+- No role-level `registries.conf` management is needed. All image references
+  in scope use fully-qualified names (e.g. `docker.io/python:trixie`). Podman's
+  default `/etc/containers/registries.conf` already includes `docker.io` as an
+  unqualified-search registry.
+
+- No Ubuntu version pre-flight assert is added. The role targets Ubuntu 22.04
+  LTS and later; a version check is out of scope (YAGNI / Principle IV).
+
+- The calling playbook MUST set `become: true` at play level. The role itself
+  does not set `become: true` on individual tasks.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After one playbook run on a fresh Ubuntu VM, every user in
+  `desktop_user_names` can execute `podman --version` without errors.
+
+- **SC-002**: After one playbook run, a user in `desktop_user_names` can
+  successfully build the repository's development container image using
+  `podman build` and run it using `podman run` without root privileges.
+
+- **SC-003**: A second consecutive playbook run against an already-configured
+  host reports zero changed tasks (full idempotency).
+
+- **SC-004**: Every user in `desktop_user_names` has a subuid and subgid range
+  entry present in `/etc/subuid` and `/etc/subgid` respectively.

--- a/specs/006-podman-rootless-role/spec.md
+++ b/specs/006-podman-rootless-role/spec.md
@@ -32,7 +32,7 @@ confirm end-to-end container workflows work.
    succeeds for every listed user.
 
 2. **Given** Podman is installed for all listed users, **When** a user runs
-   `podman build -t devcontainer -f .devcontainer/Dockerfile .` from the
+   `podman build -t devcontainer .devcontainer/` from the
    repository root, **Then** the build completes without errors.
 
 3. **Given** a container image named `devcontainer` exists in the user's local

--- a/specs/006-podman-rootless-role/tasks.md
+++ b/specs/006-podman-rootless-role/tasks.md
@@ -1,0 +1,243 @@
+# Tasks: Rootless Podman Ansible Role
+
+**Input**: Design documents from `/specs/006-podman-rootless-role/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Organization**: Tasks are grouped by user story to enable independent
+implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Exact file paths are included in all descriptions
+
+---
+
+## Phase 1: Setup (Role Skeleton)
+
+**Purpose**: Create the `roles/podman/` directory structure that all subsequent
+tasks depend on. No implementation logic yet.
+
+- [X] T001 Create role directory skeleton: `roles/podman/defaults/`,
+  `roles/podman/meta/`, `roles/podman/tasks/`
+- [X] T002 [P] Create stub `roles/podman/defaults/main.yml` with SPDX header only
+- [X] T003 [P] Create stub `roles/podman/meta/main.yml` with SPDX header only
+- [X] T004 [P] Create stub `roles/podman/tasks/main.yml` with SPDX header only
+
+**Checkpoint**: All role directories and stub files exist; playbook can reference
+the role without errors.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Populate role metadata and defaults — required before any task
+logic can reference role variables.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T005 Implement `roles/podman/defaults/main.yml` — declare
+  `podman_subuid_start: 100000`, `podman_subuid_count: 65536`,
+  `podman_subgid_start: 100000`, `podman_subgid_count: 65536`
+- [X] T006 [P] Implement `roles/podman/meta/main.yml` — set `galaxy_info`
+  with author, description (`Install and configure rootless Podman on Ubuntu`),
+  license (`MIT-0`), and platforms (`Ubuntu 22.04+`)
+
+**Checkpoint**: Role variables are declared with sensible defaults; meta is
+complete. User story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 — Install and Run Podman (P1 — MVP)
+
+**Goal**: Every desktop user listed in `desktop_user_names` can invoke `podman`
+from their own login shell after one playbook run.
+
+**Independent Test**: Run the playbook against a fresh Ubuntu VM, then log in
+as one of the target users and run `podman --version`. A version string proves
+the tool is present and accessible. Follow
+`specs/006-podman-rootless-role/quickstart.md` steps 1–2.
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Add Podman install task to `roles/podman/tasks/main.yml` —
+  `ansible.builtin.apt: name=podman state=present` with `become: true`
+  inherited from play level
+- [X] T008 [US1] Verify `roles/podman/tasks/main.yml` uses fully-qualified
+  `ansible.builtin.apt` module name per FR-005
+  *(human review checkpoint — no file changes produced)*
+
+**Checkpoint**: After running the playbook, `podman --version` succeeds for
+every user in `desktop_user_names`.
+
+---
+
+## Phase 4: User Story 2 — Rootless Configuration Per User (Priority: P2)
+
+**Goal**: Every listed desktop user has valid `/etc/subuid` and `/etc/subgid`
+range entries, enabling rootless container operation.
+
+**Independent Test**: After the role runs, inspect `/etc/subuid` and
+`/etc/subgid` — each user in `desktop_user_names` must have a valid
+`username:100000:65536` entry. Run `podman run --rm hello-world` as one of
+those users to confirm rootless operation works end-to-end.
+
+### Implementation for User Story 2
+
+- [X] T009 [US2] Add subuid loop task to `roles/podman/tasks/main.yml` —
+  `ansible.builtin.lineinfile` on `/etc/subuid` with
+  `regexp: '^{{ item }}:'`,
+  `line: '{{ item }}:{{ podman_subuid_start }}:{{ podman_subuid_count }}'`,
+  looping over `desktop_user_names`
+- [X] T010 [P] [US2] Add subgid loop task to `roles/podman/tasks/main.yml` —
+  `ansible.builtin.lineinfile` on `/etc/subgid` with
+  `regexp: '^{{ item }}:'`,
+  `line: '{{ item }}:{{ podman_subgid_start }}:{{ podman_subgid_count }}'`,
+  looping over `desktop_user_names`
+- [X] T011 [US2] Add `podman system migrate` task to
+  `roles/podman/tasks/main.yml` —
+  `ansible.builtin.command: podman system migrate` with
+  `become_user: "{{ item }}"`, `loop: "{{ desktop_user_names }}"`,
+  and `changed_when: false`
+
+**Checkpoint**: After running the playbook, `/etc/subuid` and `/etc/subgid`
+contain valid entries for every listed user, and `podman run --rm hello-world`
+succeeds rootlessly.
+
+---
+
+## Phase 5: User Story 3 — Idempotent Re-Runs (Priority: P3)
+
+**Goal**: A second consecutive playbook run on a fully-configured host reports
+zero changed tasks.
+
+**Independent Test**: Run the playbook twice in sequence. The second run must
+report zero changed tasks (all tasks report `ok` or `skipped`). Follow
+`specs/006-podman-rootless-role/quickstart.md` step 3.
+
+### Implementation for User Story 3
+
+- [X] T012 [US3] Verify `ansible.builtin.apt` task in
+  `roles/podman/tasks/main.yml` uses `state: present` (not `state: latest`)
+  to avoid spurious changes
+- [X] T013 [US3] Verify `ansible.builtin.lineinfile` tasks in
+  `roles/podman/tasks/main.yml` have start-anchored `regexp: '^{{ item }}:'`
+  to prevent duplicates
+  *(human review checkpoint — no file changes produced)*
+- [X] T014 [US3] Verify `podman system migrate` task in
+  `roles/podman/tasks/main.yml` has `changed_when: false` per FR-006
+  *(human review checkpoint — no file changes produced)*
+
+**Checkpoint**: All three verification tasks confirm the idempotency mechanisms
+are in place. A second playbook run reports zero changed tasks.
+
+---
+
+## Phase 6: Polish and Cross-Cutting Concerns
+
+**Purpose**: Documentation and integration — affects all user stories.
+
+- [X] T015 [P] Create `roles/podman/README.md` — document role purpose,
+  variables table (`podman_subuid_start`, `podman_subuid_count`,
+  `podman_subgid_start`, `podman_subgid_count`), example playbook snippet,
+  and MIT-0 licence notice
+- [X] T016 [P] Create `roles/podman/DESIGN.md` — document non-obvious design
+  decisions: lineinfile idempotency strategy (Decision 2),
+  `podman system migrate` `changed_when: false` guard (Decision 3),
+  play-level `become` convention (Decision 5)
+- [X] T017 Add `podman` to the `roles:` list in `configure-linux-roles.yml`
+  following `specs/006-podman-rootless-role/quickstart.md` "Adding the Role"
+  section. After inserting the role, run the playbook with only `podman`
+  active against a local VM and confirm it completes without errors.
+- [X] T018 [P] Apply the `format-markdown` skill to all new Markdown files in
+  `roles/podman/` (README.md and DESIGN.md) to verify Markdown quality
+  (Principle VI)
+- [ ] T020 Run full acceptance test checklist from
+  `specs/006-podman-rootless-role/quickstart.md` against the local VM
+- [X] T021 Verify that `roles/podman/tasks/main.yml` contains no reference to
+  `podman-docker` — covers FR-011
+  *(human review checkpoint — no file changes produced)*
+
+---
+
+## Dependencies and Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 — BLOCKS all user stories
+- **Phase 3 (US1)**: Depends on Phase 2
+- **Phase 4 (US2)**: Depends on Phase 3 — subuid/subgid tasks reference Podman
+  which must already be installed
+- **Phase 5 (US3)**: Depends on Phases 3 and 4 — idempotency verification
+  requires all task implementations to be complete
+- **Phase 6 (Polish)**: Depends on Phases 3, 4, and 5
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Starts after Phase 2. No dependency on US2 or US3.
+- **User Story 2 (P2)**: Starts after US1 is complete (Podman must be installed
+  before `podman system migrate` can run).
+- **User Story 3 (P3)**: Starts after US1 and US2 are complete (all task
+  implementations must exist before idempotency can be verified).
+
+### Within Each User Story
+
+- T009 (subuid) and T010 (subgid) are independently parallelisable — different
+  files, no mutual dependency.
+- T011 (migrate) depends on T009 and T010.
+
+### Parallel Opportunities
+
+- T002, T003, T004 (Phase 1 stubs) can run in parallel.
+- T005 and T006 (Phase 2) can run in parallel.
+- T009 and T010 (Phase 4 lineinfile tasks) can run in parallel.
+- T015, T016, T018 (Phase 6 documentation) can run in parallel.
+
+---
+
+## Parallel Example: Phase 4
+
+```text
+# Run these two tasks in parallel (different target files):
+T009 [US2] lineinfile on /etc/subuid
+T010 [P] [US2] lineinfile on /etc/subgid
+
+# Then run sequentially:
+T011 [US2] podman system migrate (depends on T009 + T010)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP Scope (User Story 1 Only)
+
+1. Complete Phase 1: Setup (role skeleton)
+2. Complete Phase 2: Foundational (defaults + meta)
+3. Complete Phase 3: User Story 1 (install Podman)
+4. **STOP and VALIDATE**: `podman --version` succeeds for every listed user
+5. Proceed to Phase 4 once US1 is confirmed
+
+### Incremental Delivery
+
+1. Phase 1 + Phase 2 → role skeleton with defaults and meta
+2. Phase 3 (US1) → Podman installed; `podman --version` works
+3. Phase 4 (US2) → rootless configuration; `podman run --rm hello-world` works
+4. Phase 5 (US3) → idempotency verified; second run is clean
+5. Phase 6 (Polish) → documentation complete; role integrated into playbook
+
+---
+
+## Notes
+
+- All YAML files in `roles/podman/` MUST carry `# SPDX-License-Identifier: MIT-0`
+  as their first line (FR-009).
+- All module references MUST use fully-qualified `ansible.builtin.*` names
+  (FR-005).
+- No `handlers/`, `templates/`, or `files/` directories are needed per plan.md.
+- `desktop_user_names` has no role-level default; the calling playbook must
+  supply it. An empty list is valid — per-user loop tasks are skipped.
+- The `podman system migrate` task runs with `become_user: "{{ item }}"` and
+  inherits `become: true` from the play level (Decision 5 in research.md).

--- a/specs/006-podman-rootless-role/tasks.md
+++ b/specs/006-podman-rootless-role/tasks.md
@@ -153,7 +153,7 @@ are in place. A second playbook run reports zero changed tasks.
 - [X] T018 [P] Apply the `format-markdown` skill to all new Markdown files in
   `roles/podman/` (README.md and DESIGN.md) to verify Markdown quality
   (Principle VI)
-- [ ] T020 Run full acceptance test checklist from
+- [X] T020 Run full acceptance test checklist from
   `specs/006-podman-rootless-role/quickstart.md` against the local VM
 - [X] T021 Verify that `roles/podman/tasks/main.yml` contains no reference to
   `podman-docker` — covers FR-011


### PR DESCRIPTION
## Summary

  Adds a new `roles/podman/` Ansible role that installs rootless Podman on                                                                                              
  Ubuntu and configures `/etc/subuid` and `/etc/subgid` per desktop user.
  This is a prerequisite for running the `.devcontainer/` Ansible control                                                                                               
  node container inside a sandboxed Linux VM.                                                                                                                           
                                                                                                                                                                        
  ## What's included                                                                                                                                                    
                                                                                                                                                                        
  - **`roles/podman/`** — installs Podman via `apt`, configures subuid/subgid                                                                                           
    with `lineinfile` (idempotent), runs `podman system migrate` per user
  - **Molecule scenario** for `roles/podman/` — full create → prepare →                                                                                                 
    converge → idempotence → verify → destroy lifecycle                                                                                                                 
  - **Molecule scenario** for `roles/java/` — validates Temurin JDK install                                                                                             
    in a Podman container (required the same driver setup)                                                                                                              
  - **Molecule testing standard** — constitution amended to v1.2.0; new rule                                                                                            
    `340-molecule-testing.mdc`; `CONTRIBUTING.md` updated with single-role                                                                                              
    and all-roles test commands                                                                                                                                         
  - **`scripts/test-molecule-all.sh`** — helper script to run all role                                                                                                  
    scenarios in one call with a pass/fail summary                                                                                                                      
                                                                                                                                                                        
  ## Acceptance criteria (all verified on hobbiton, Ubuntu 24.04)                                                                                                       
                                                                                                                                                                        
  - `podman --version` succeeds after role apply                                                                                                                        
  - `/etc/subuid` and `/etc/subgid` contain the correct entries per user
  - `podman build -t devcontainer .devcontainer/` succeeds                                                                                                              
  - `podman run --rm devcontainer ansible --version` returns `ansible [core 2.20.4]`                                                                                    
  - Second playbook run: zero `changed` tasks