### PR TITLE
fix: backed up ~/.tmux.conf would be downgraded on restore

### DIFF
--- a/playbooks/backup/home-folder-files.yml
+++ b/playbooks/backup/home-folder-files.yml
@@ -12,5 +12,4 @@
       vars:
         path:
           - "/home/{{ backup_user }}/.gitconfig"
-          - "/home/{{ backup_user }}/.tmux.conf"
         backup_file: "home-folder-files-backup.tar.gz"


### PR DESCRIPTION
The tmux role deploys ~/.tmux.conf via ansible.builtin.copy on every configure run. Backing it up and restoring it would replace the role-managed version with a potentially outdated copy.

🤖 Generated with [Claude Code](https://claude.ai/code)