### PR TITLE
feat: add dolt_sql_server role with loopback SQL server on VM boot

### DIFF
--- a/configure-linux-roles.yml
+++ b/configure-linux-roles.yml
@@ -15,6 +15,7 @@
     - podman
     - claude_code
     - tmux
+    - dolt_sql_server
     - role: google_chrome
       tags: not-supported-on-vagrant-arm64
 

--- a/docs/architecture/version-update-playbooks.md
+++ b/docs/architecture/version-update-playbooks.md
@@ -103,6 +103,7 @@ Tracked tools and their upstream sources:
 | Nerd Fonts (Hack) | `tmux` | `tmux_font_version` | — | GitHub Releases API (`ryanoasis/nerd-fonts`) |
 | Android cmdline-tools | `android_studio` | `android_cmdlinetools_build` | `android_cmdlinetools_sha1` (sha1) | HTML scrape `developer.android.com/studio` |
 | Java (Temurin) | `java` | `java_sdkman_identifier` | — | SDKMAN REST API |
+| Dolt | `dolt_sql_server` | `dolt_version` | — | GitHub Releases API (`dolthub/dolt`) |
 
 `fetch-github-release.yml` is parametrized via a `github_repo`
 variable and called twice (once for gitmux, once for Nerd Fonts),

--- a/docs/architecture/version-update-playbooks.md
+++ b/docs/architecture/version-update-playbooks.md
@@ -103,7 +103,7 @@ Tracked tools and their upstream sources:
 | Nerd Fonts (Hack) | `tmux` | `tmux_font_version` | — | GitHub Releases API (`ryanoasis/nerd-fonts`) |
 | Android cmdline-tools | `android_studio` | `android_cmdlinetools_build` | `android_cmdlinetools_sha1` (sha1) | HTML scrape `developer.android.com/studio` |
 | Java (Temurin) | `java` | `java_sdkman_identifier` | — | SDKMAN REST API |
-| Dolt | `dolt_sql_server` | `dolt_version` | — | GitHub Releases API (`dolthub/dolt`) |
+| Dolt | `dolt_sql_server` | `dolt_version` | `dolt_sha256_amd64` / `dolt_sha256_arm64` (sha256) | GitHub Releases API (`dolthub/dolt`) |
 
 `fetch-github-release.yml` is parametrized via a `github_repo`
 variable and called twice (once for gitmux, once for Nerd Fonts),

--- a/playbooks/update-versions/perform-updates.yml
+++ b/playbooks/update-versions/perform-updates.yml
@@ -115,3 +115,41 @@
         path: "{{ _roles_dir }}/dolt_sql_server/defaults/main.yml"
         regexp: 'dolt_version:\s*"[^"]+"'
         replace: 'dolt_version: "{{ fetched_dolt_tag }}"'
+
+    - name: Download dolt amd64 tarball for sha256 computation
+      ansible.builtin.get_url:
+        url: "https://github.com/dolthub/dolt/releases/download/{{ fetched_dolt_tag }}/dolt-linux-amd64.tar.gz"
+        dest: "/tmp/dolt-{{ fetched_dolt_tag }}-linux-amd64.tar.gz"
+        mode: '0644'
+
+    - name: Compute sha256 of dolt amd64 tarball
+      ansible.builtin.stat:
+        path: "/tmp/dolt-{{ fetched_dolt_tag }}-linux-amd64.tar.gz"
+        checksum_algorithm: sha256
+        get_checksum: true
+      register: _dolt_amd64_stat
+
+    - name: Update dolt_sha256_amd64 in dolt_sql_server role defaults
+      ansible.builtin.replace:
+        path: "{{ _roles_dir }}/dolt_sql_server/defaults/main.yml"
+        regexp: 'dolt_sha256_amd64:\s*"[^"]+"'
+        replace: 'dolt_sha256_amd64: "{{ _dolt_amd64_stat.stat.checksum }}"'
+
+    - name: Download dolt arm64 tarball for sha256 computation
+      ansible.builtin.get_url:
+        url: "https://github.com/dolthub/dolt/releases/download/{{ fetched_dolt_tag }}/dolt-linux-arm64.tar.gz"
+        dest: "/tmp/dolt-{{ fetched_dolt_tag }}-linux-arm64.tar.gz"
+        mode: '0644'
+
+    - name: Compute sha256 of dolt arm64 tarball
+      ansible.builtin.stat:
+        path: "/tmp/dolt-{{ fetched_dolt_tag }}-linux-arm64.tar.gz"
+        checksum_algorithm: sha256
+        get_checksum: true
+      register: _dolt_arm64_stat
+
+    - name: Update dolt_sha256_arm64 in dolt_sql_server role defaults
+      ansible.builtin.replace:
+        path: "{{ _roles_dir }}/dolt_sql_server/defaults/main.yml"
+        regexp: 'dolt_sha256_arm64:\s*"[^"]+"'
+        replace: 'dolt_sha256_arm64: "{{ _dolt_arm64_stat.stat.checksum }}"'

--- a/playbooks/update-versions/perform-updates.yml
+++ b/playbooks/update-versions/perform-updates.yml
@@ -51,6 +51,15 @@
     - name: Fetch Android cmdline-tools upstream version
       ansible.builtin.include_tasks: tasks/fetch-android-version.yml
 
+    - name: Fetch Dolt upstream version
+      ansible.builtin.include_tasks: tasks/fetch-github-release.yml
+      vars:
+        github_repo: "dolthub/dolt"
+
+    - name: Save Dolt fetched tag
+      ansible.builtin.set_fact:
+        fetched_dolt_tag: "{{ fetched_github_tag }}"
+
     # --- Apply updates to role defaults files ---
 
     # Flutter SDK: version and sha256 updated together
@@ -99,3 +108,10 @@
         path: "{{ _roles_dir }}/android_studio/defaults/main.yml"
         regexp: 'android_cmdlinetools_sha1:\s*"[^"]+"'
         replace: 'android_cmdlinetools_sha1: "{{ fetched_android_sha1 }}"'
+
+    # Dolt
+    - name: Update dolt_version in dolt_sql_server role defaults
+      ansible.builtin.replace:
+        path: "{{ _roles_dir }}/dolt_sql_server/defaults/main.yml"
+        regexp: 'dolt_version:\s*"[^"]+"'
+        replace: 'dolt_version: "{{ fetched_dolt_tag }}"'

--- a/playbooks/update-versions/query-versions.yml
+++ b/playbooks/update-versions/query-versions.yml
@@ -27,6 +27,11 @@
         src: "{{ _roles_dir }}/java/defaults/main.yml"
       register: _java_defaults_raw
 
+    - name: Read dolt_sql_server role defaults
+      ansible.builtin.slurp:
+        src: "{{ _roles_dir }}/dolt_sql_server/defaults/main.yml"
+      register: _dolt_defaults_raw
+
     - name: Extract current pinned values from role defaults
       vars:
         _java_id_match: >-
@@ -52,6 +57,10 @@
              | default([], true) | first }}
         current_java_identifier: "{{ _java_id_match | first }}"
         _current_java_major: "{{ (_java_id_match | first).split('.')[0] | int }}"
+        current_dolt_version: >-
+          {{ _dolt_defaults_raw.content | b64decode
+             | regex_search('dolt_version:\s*"([^"]+)"', '\1')
+             | default([], true) | first }}
 
     # --- Fetch upstream versions ---
     - name: Fetch Flutter upstream version
@@ -82,6 +91,15 @@
 
     - name: Fetch Android cmdline-tools upstream version
       ansible.builtin.include_tasks: tasks/fetch-android-version.yml
+
+    - name: Fetch Dolt upstream version
+      ansible.builtin.include_tasks: tasks/fetch-github-release.yml
+      vars:
+        github_repo: "dolthub/dolt"
+
+    - name: Save Dolt fetched tag
+      ansible.builtin.set_fact:
+        fetched_dolt_tag: "{{ fetched_github_tag }}"
 
     # --- Compare and report ---
     - name: Report Flutter SDK version status
@@ -124,6 +142,14 @@
           upstream={{ fetched_android_build }},
           status={{ 'UP TO DATE' if current_android_build == fetched_android_build else 'STALE' }}
 
+    - name: Report Dolt version status
+      ansible.builtin.debug:
+        msg: >-
+          Dolt:
+          current={{ current_dolt_version }},
+          upstream={{ fetched_dolt_tag }},
+          status={{ 'UP TO DATE' if current_dolt_version == fetched_dolt_tag else 'STALE' }}
+
     - name: Fail if any version pins are stale
       ansible.builtin.fail:
         msg: >-
@@ -133,4 +159,5 @@
         current_tmux_gitmux_version != fetched_gitmux_tag or
         current_tmux_font_version != fetched_font_tag or
         current_java_identifier != fetched_java_identifier or
-        current_android_build != fetched_android_build
+        current_android_build != fetched_android_build or
+        current_dolt_version != fetched_dolt_tag

--- a/roles/dolt_sql_server/README.md
+++ b/roles/dolt_sql_server/README.md
@@ -1,0 +1,77 @@
+# dolt_sql_server
+
+Installs the [Dolt](https://github.com/dolthub/dolt) binary at a pinned version
+and runs `dolt sql-server` as a systemd service on Ubuntu. The server binds to
+loopback (`127.0.0.1:3306`) and restarts on failure. Multiple parallel agent
+sessions on the same VM can write task-tracking data simultaneously without
+lock-contention failures.
+
+**Boundary**: this role installs the binary and manages the service only. It
+does not initialize databases, restore or back up data, or configure any
+repository's task-tracking settings — those are session-level operations.
+
+See [`specs/008-dolt-sql-server-role/quickstart.md`](../../specs/008-dolt-sql-server-role/quickstart.md)
+for build, test, and validation procedures.
+
+## Variables
+
+All variables have safe defaults. None are required from the caller.
+
+| Variable | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `dolt_version` | string | `"v2.0.8"` | Pinned Dolt release tag (`v`-prefixed). |
+| `dolt_install_path` | string | `/usr/local/bin/dolt` | Path where the `dolt` binary is placed. |
+| `dolt_listen_host` | string | `127.0.0.1` | Listener address. Must be `127.0.0.1` (loopback only; asserted). |
+| `dolt_listen_port` | integer | `3306` | Listener port. Must be 1–65535 (asserted). |
+| `dolt_data_dir` | string | `/var/lib/dolt` | Server data directory. |
+| `dolt_config_dir` | string | `/etc/dolt` | Directory containing `config.yaml`. |
+| `dolt_config_path` | string | `"{{ dolt_config_dir }}/config.yaml"` | Full path to the rendered server config. |
+| `dolt_service_user` | string | `dolt` | System user the service runs as. |
+| `dolt_service_name` | string | `dolt-sql-server` | Systemd service unit name. |
+| `dolt_readiness_timeout` | integer | `30` | Seconds to wait for the server to accept connections after start. |
+
+Overriding `dolt_listen_host` to a non-loopback address is rejected by an
+`assert` (FR-007).
+
+## Postconditions
+
+On a successful run against a systemd host:
+
+- `dolt` binary at `dolt_install_path` reports the pinned version.
+- `dolt-sql-server.service` is **enabled** (starts on every boot) and
+  **active**, with `Restart=always` (auto-restarts on failure).
+- Server listens on `127.0.0.1:3306` only — not on any external interface.
+- Server accepts connections and is ready for `bd init --server` with no
+  additional server-side configuration.
+- Re-running the role on an already-provisioned host makes no changes and does
+  not restart the running service.
+
+## Developer opt-in (US2)
+
+After provisioning, a developer opts a git repository into Dolt-backed task
+tracking with a single command:
+
+```bash
+cd /path/to/git/repo      # repository must have at least one commit
+bd init --server           # connects to 127.0.0.1:3306, root, no password
+```
+
+Verify that tasks are stored in Dolt (not an embedded fallback):
+
+```bash
+bd create --title="Test task" --type=task
+dolt sql-client --host 127.0.0.1 --port 3306 --user root \
+  --execute "SHOW DATABASES;"   # repository-prefix database should be present
+```
+
+This is a per-repository developer action. The role does not perform it
+automatically and has no knowledge of any specific repository.
+
+## Non-goals
+
+- Database initialization (`dolt init`) — handled by `bd bootstrap` at session start.
+- Data restore or backup — handled by `bd dolt push` / `bd dolt pull`
+  at session boundaries.
+- Repository task-tracking configuration (`bd init --server`) — a
+  one-time developer action.
+- Multi-host or remote server setup — the service is local to each VM.

--- a/roles/dolt_sql_server/README.md
+++ b/roles/dolt_sql_server/README.md
@@ -31,7 +31,7 @@ All variables have safe defaults. None are required from the caller.
 | `dolt_readiness_timeout` | integer | `30` | Seconds to wait for the server to accept connections after start. |
 
 Overriding `dolt_listen_host` to a non-loopback address is rejected by an
-`assert` (FR-007).
+`assert` at role entry.
 
 ## Postconditions
 

--- a/roles/dolt_sql_server/README.md
+++ b/roles/dolt_sql_server/README.md
@@ -20,6 +20,8 @@ All variables have safe defaults. None are required from the caller.
 | Variable | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `dolt_version` | string | `"v2.0.8"` | Pinned Dolt release tag (`v`-prefixed). |
+| `dolt_sha256_amd64` | string | *(see defaults)* | SHA-256 of the `dolt-linux-amd64.tar.gz` tarball for `dolt_version`. Updated by `perform-updates.yml`. |
+| `dolt_sha256_arm64` | string | *(see defaults)* | SHA-256 of the `dolt-linux-arm64.tar.gz` tarball for `dolt_version`. Updated by `perform-updates.yml`. |
 | `dolt_install_path` | string | `/usr/local/bin/dolt` | Path where the `dolt` binary is placed. |
 | `dolt_listen_host` | string | `127.0.0.1` | Listener address. Must be `127.0.0.1` (loopback only; asserted). |
 | `dolt_listen_port` | integer | `3306` | Listener port. Must be 1–65535 (asserted). |

--- a/roles/dolt_sql_server/defaults/main.yml
+++ b/roles/dolt_sql_server/defaults/main.yml
@@ -1,6 +1,14 @@
 #SPDX-License-Identifier: MIT-0
 ---
 dolt_version: "v2.0.8"
+# SHA-256 checksums for the linux release tarballs (amd64 and arm64).
+# All three values must be updated together when upgrading dolt_version.
+# Compute (download to file first — pipe-only sha256sum can truncate and give wrong hash):
+#   curl -sL https://github.com/dolthub/dolt/releases/download/<version>/dolt-linux-<arch>.tar.gz -o /tmp/dolt.tar.gz
+#   sha256sum /tmp/dolt.tar.gz
+# Updated automatically by playbooks/update-versions/perform-updates.yml
+dolt_sha256_amd64: "cf365ce9cbd32daecb32e5dbff97e055238a8414131766151d132b32db857c3a"
+dolt_sha256_arm64: "465c9d51dcba9af6678903be519269add186c910f834684d25574ed49aaebbff"
 dolt_install_path: /usr/local/bin/dolt
 dolt_listen_host: 127.0.0.1
 dolt_listen_port: 3306

--- a/roles/dolt_sql_server/defaults/main.yml
+++ b/roles/dolt_sql_server/defaults/main.yml
@@ -1,0 +1,12 @@
+#SPDX-License-Identifier: MIT-0
+---
+dolt_version: "v2.0.8"
+dolt_install_path: /usr/local/bin/dolt
+dolt_listen_host: 127.0.0.1
+dolt_listen_port: 3306
+dolt_data_dir: /var/lib/dolt
+dolt_config_dir: /etc/dolt
+dolt_config_path: "{{ dolt_config_dir }}/config.yaml"
+dolt_service_user: dolt
+dolt_service_name: dolt-sql-server
+dolt_readiness_timeout: 30

--- a/roles/dolt_sql_server/handlers/main.yml
+++ b/roles/dolt_sql_server/handlers/main.yml
@@ -1,0 +1,8 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Restart dolt-sql-server
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+    name: "{{ dolt_service_name }}"
+    state: restarted
+  when: ansible_facts['service_mgr'] == 'systemd'

--- a/roles/dolt_sql_server/meta/main.yml
+++ b/roles/dolt_sql_server/meta/main.yml
@@ -1,0 +1,19 @@
+#SPDX-License-Identifier: MIT-0
+---
+galaxy_info:
+  author: Stefan Boos
+  namespace: wonderbird
+  role_name: dolt_sql_server
+  description: Install and run Dolt SQL server as a systemd service on Ubuntu
+  company: n.a.
+  issue_tracker_url: https://github.com/wonderbird/ansible-all-my-things/issues
+  license: MIT-0
+  min_ansible_version: 2.19
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags: []
+
+dependencies: []

--- a/roles/dolt_sql_server/molecule/default/converge.yml
+++ b/roles/dolt_sql_server/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: dolt_sql_server

--- a/roles/dolt_sql_server/molecule/default/molecule.yml
+++ b/roles/dolt_sql_server/molecule/default/molecule.yml
@@ -1,0 +1,26 @@
+#SPDX-License-Identifier: MIT-0
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: docker.io/library/ubuntu:24.04
+    pre_build_image: true
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/roles/dolt_sql_server/molecule/default/prepare.yml
+++ b/roles/dolt_sql_server/molecule/default/prepare.yml
@@ -1,0 +1,16 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Prepare container
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.raw: apt-get update
+      become: false
+      changed_when: true
+
+    - name: Install python3 and sudo
+      ansible.builtin.raw: apt-get install -y -qq python3 sudo
+      become: false
+      changed_when: true

--- a/roles/dolt_sql_server/molecule/default/verify.yml
+++ b/roles/dolt_sql_server/molecule/default/verify.yml
@@ -26,7 +26,6 @@
       ansible.builtin.command:
         cmd: "grep -q 'host: 127.0.0.1' /etc/dolt/config.yaml"
       changed_when: false
-      failed_when: false
       register: _verify_config_host
 
     - name: Assert dolt config has loopback host
@@ -50,7 +49,6 @@
       ansible.builtin.command:
         cmd: grep -q 'Restart=always' /etc/systemd/system/dolt-sql-server.service
       changed_when: false
-      failed_when: false
       register: _verify_service_restart
 
     - name: Assert dolt service unit has Restart=always
@@ -63,7 +61,6 @@
       ansible.builtin.command:
         cmd: grep -q 'WantedBy=multi-user.target' /etc/systemd/system/dolt-sql-server.service
       changed_when: false
-      failed_when: false
       register: _verify_service_wanted
 
     - name: Assert dolt service unit has WantedBy=multi-user.target

--- a/roles/dolt_sql_server/molecule/default/verify.yml
+++ b/roles/dolt_sql_server/molecule/default/verify.yml
@@ -100,14 +100,6 @@
       changed_when: false
       failed_when: _verify_select1.rc != 0
 
-    - name: Assert SELECT 1 succeeded
-      ansible.builtin.assert:
-        that:
-          - _verify_select1.rc == 0
-        fail_msg: >-
-          mysql SELECT 1 failed (rc={{ _verify_select1.rc }}):
-          {{ _verify_select1.stderr }}
-
     - name: Check listener binding
       ansible.builtin.command:
         cmd: ss -tlnp

--- a/roles/dolt_sql_server/molecule/default/verify.yml
+++ b/roles/dolt_sql_server/molecule/default/verify.yml
@@ -1,0 +1,124 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    - name: Load role defaults for version reference
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/../../defaults/main.yml"
+
+    - name: Get installed dolt version
+      ansible.builtin.command:
+        cmd: /usr/local/bin/dolt version
+      register: _verify_dolt_version
+      changed_when: false
+
+    - name: Assert dolt version matches pinned version
+      ansible.builtin.assert:
+        that:
+          - (dolt_version | regex_replace('^v', '')) in _verify_dolt_version.stdout
+        fail_msg: >-
+          Expected dolt version {{ dolt_version | regex_replace('^v', '') }}
+          but got: {{ _verify_dolt_version.stdout }}
+
+    - name: Check dolt config contains loopback host
+      ansible.builtin.command:
+        cmd: "grep -q 'host: 127.0.0.1' /etc/dolt/config.yaml"
+      changed_when: false
+      failed_when: false
+      register: _verify_config_host
+
+    - name: Assert dolt config has loopback host
+      ansible.builtin.assert:
+        that:
+          - _verify_config_host.rc == 0
+        fail_msg: "/etc/dolt/config.yaml does not contain 'host: 127.0.0.1'"
+
+    - name: Stat dolt systemd service unit file
+      ansible.builtin.stat:
+        path: /etc/systemd/system/dolt-sql-server.service
+      register: _verify_service_stat
+
+    - name: Assert dolt service unit file exists
+      ansible.builtin.assert:
+        that:
+          - _verify_service_stat.stat.exists
+        fail_msg: "/etc/systemd/system/dolt-sql-server.service does not exist"
+
+    - name: Check dolt service unit contains Restart=always
+      ansible.builtin.command:
+        cmd: grep -q 'Restart=always' /etc/systemd/system/dolt-sql-server.service
+      changed_when: false
+      failed_when: false
+      register: _verify_service_restart
+
+    - name: Assert dolt service unit has Restart=always
+      ansible.builtin.assert:
+        that:
+          - _verify_service_restart.rc == 0
+        fail_msg: "/etc/systemd/system/dolt-sql-server.service does not contain Restart=always"
+
+    - name: Check dolt service unit contains WantedBy=multi-user.target
+      ansible.builtin.command:
+        cmd: grep -q 'WantedBy=multi-user.target' /etc/systemd/system/dolt-sql-server.service
+      changed_when: false
+      failed_when: false
+      register: _verify_service_wanted
+
+    - name: Assert dolt service unit has WantedBy=multi-user.target
+      ansible.builtin.assert:
+        that:
+          - _verify_service_wanted.rc == 0
+        fail_msg: "/etc/systemd/system/dolt-sql-server.service does not contain WantedBy=multi-user.target"
+
+    - name: Install packages for smoke test
+      ansible.builtin.apt:
+        name:
+          - default-mysql-client
+          - iproute2
+        state: present
+        update_cache: false
+
+    - name: Start dolt sql-server for smoke test
+      ansible.builtin.command:
+        cmd: /usr/local/bin/dolt sql-server --config /etc/dolt/config.yaml
+      async: 300
+      poll: 0
+      changed_when: true
+
+    - name: Wait for dolt SQL server to accept connections
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 3306
+        timeout: 30
+
+    - name: Run SELECT 1 via mysql client
+      ansible.builtin.command:
+        cmd: mysql --host=127.0.0.1 --port=3306 --user=root --execute="SELECT 1"
+      register: _verify_select1
+      changed_when: false
+      failed_when: _verify_select1.rc != 0
+
+    - name: Assert SELECT 1 succeeded
+      ansible.builtin.assert:
+        that:
+          - _verify_select1.rc == 0
+        fail_msg: >-
+          mysql SELECT 1 failed (rc={{ _verify_select1.rc }}):
+          {{ _verify_select1.stderr }}
+
+    - name: Check listener binding
+      ansible.builtin.command:
+        cmd: ss -tlnp
+      register: _verify_ss
+      changed_when: false
+
+    - name: Assert server listens on loopback only
+      ansible.builtin.assert:
+        that:
+          - "'127.0.0.1:3306' in _verify_ss.stdout"
+          - "'0.0.0.0:3306' not in _verify_ss.stdout"
+        fail_msg: >-
+          Expected 127.0.0.1:3306 (not 0.0.0.0:3306).
+          ss output: {{ _verify_ss.stdout }}

--- a/roles/dolt_sql_server/tasks/main.yml
+++ b/roles/dolt_sql_server/tasks/main.yml
@@ -51,7 +51,7 @@
 
 - name: Set dolt target architecture
   ansible.builtin.set_fact:
-    _dolt_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}"
+    _dolt_arch: "{{ 'amd64' if ansible_facts['architecture'] == 'x86_64' else 'arm64' }}"
   when: _dolt_needs_install
 
 - name: Download dolt release tarball

--- a/roles/dolt_sql_server/tasks/main.yml
+++ b/roles/dolt_sql_server/tasks/main.yml
@@ -60,6 +60,7 @@
       https://github.com/dolthub/dolt/releases/download/{{ dolt_version }}/dolt-linux-{{ _dolt_arch }}.tar.gz
     dest: "/tmp/dolt-{{ dolt_version }}-linux-{{ _dolt_arch }}.tar.gz"
     mode: '0644'
+    checksum: "sha256:{{ dolt_sha256_amd64 if _dolt_arch == 'amd64' else dolt_sha256_arm64 }}"
   when: _dolt_needs_install
 
 - name: Extract dolt release tarball

--- a/roles/dolt_sql_server/tasks/main.yml
+++ b/roles/dolt_sql_server/tasks/main.yml
@@ -1,0 +1,126 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Validate required variables
+  ansible.builtin.assert:
+    that:
+      - dolt_version | length > 0
+      - dolt_listen_host == '127.0.0.1'
+      - dolt_listen_port | int >= 1
+      - dolt_listen_port | int <= 65535
+    fail_msg: >-
+      Variable validation failed: dolt_version must be non-empty,
+      dolt_listen_host must be 127.0.0.1 (loopback only),
+      dolt_listen_port must be an integer between 1 and 65535.
+
+- name: Create dolt service user
+  ansible.builtin.user:
+    name: "{{ dolt_service_user }}"
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+
+- name: Create dolt data and config directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ dolt_service_user }}"
+    group: "{{ dolt_service_user }}"
+    mode: '0750'
+  loop:
+    - "{{ dolt_data_dir }}"
+    - "{{ dolt_config_dir }}"
+
+- name: Check if dolt binary is installed
+  ansible.builtin.stat:
+    path: "{{ dolt_install_path }}"
+  register: _dolt_binary_stat
+
+- name: Get installed dolt version
+  ansible.builtin.command:
+    cmd: "{{ dolt_install_path }} version"
+  register: _dolt_installed_version
+  changed_when: false
+  when: _dolt_binary_stat.stat.exists
+
+- name: Determine if dolt installation is required
+  ansible.builtin.set_fact:
+    _dolt_needs_install: >-
+      {{ not _dolt_binary_stat.stat.exists or
+         (dolt_version | regex_replace('^v', '')) not in
+         (_dolt_installed_version.stdout | default('')) }}
+
+- name: Set dolt target architecture
+  ansible.builtin.set_fact:
+    _dolt_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}"
+  when: _dolt_needs_install
+
+- name: Download dolt release tarball
+  ansible.builtin.get_url:
+    url: >-
+      https://github.com/dolthub/dolt/releases/download/{{ dolt_version }}/dolt-linux-{{ _dolt_arch }}.tar.gz
+    dest: "/tmp/dolt-{{ dolt_version }}-linux-{{ _dolt_arch }}.tar.gz"
+    mode: '0644'
+  when: _dolt_needs_install
+
+- name: Extract dolt release tarball
+  ansible.builtin.unarchive:
+    src: "/tmp/dolt-{{ dolt_version }}-linux-{{ _dolt_arch }}.tar.gz"
+    dest: /tmp
+    remote_src: true
+  when: _dolt_needs_install
+
+- name: Install dolt binary
+  ansible.builtin.copy:
+    src: "/tmp/dolt-linux-{{ _dolt_arch }}/bin/dolt"
+    dest: "{{ dolt_install_path }}"
+    remote_src: true
+    mode: '0755'
+    owner: root
+    group: root
+  when: _dolt_needs_install
+
+- name: Deploy dolt server config
+  ansible.builtin.template:
+    src: config.yaml.j2
+    dest: "{{ dolt_config_path }}"
+    owner: "{{ dolt_service_user }}"
+    group: "{{ dolt_service_user }}"
+    mode: '0640'
+  notify: Restart dolt-sql-server
+
+- name: Deploy dolt systemd service unit
+  ansible.builtin.template:
+    src: dolt-sql-server.service.j2
+    dest: "/etc/systemd/system/{{ dolt_service_name }}.service"
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart dolt-sql-server
+
+- name: Enable and start dolt-sql-server service
+  ansible.builtin.systemd_service:
+    name: "{{ dolt_service_name }}"
+    daemon_reload: true
+    enabled: true
+    state: started
+  when: ansible_facts['service_mgr'] == 'systemd'
+
+- name: Wait for dolt SQL server to be ready
+  ansible.builtin.wait_for:
+    host: "{{ dolt_listen_host }}"
+    port: "{{ dolt_listen_port }}"
+    timeout: "{{ dolt_readiness_timeout }}"
+  register: _dolt_readiness
+  when: ansible_facts['service_mgr'] == 'systemd'
+
+- name: Assert dolt SQL server is listening
+  ansible.builtin.assert:
+    that:
+      - _dolt_readiness.elapsed is defined
+    fail_msg: >-
+      Dolt SQL server failed to start on
+      {{ dolt_listen_host }}:{{ dolt_listen_port }}
+    success_msg: >-
+      Dolt SQL server is ready on
+      {{ dolt_listen_host }}:{{ dolt_listen_port }}
+  when: ansible_facts['service_mgr'] == 'systemd'

--- a/roles/dolt_sql_server/templates/config.yaml.j2
+++ b/roles/dolt_sql_server/templates/config.yaml.j2
@@ -1,0 +1,4 @@
+listener:
+  host: {{ dolt_listen_host }}
+  port: {{ dolt_listen_port }}
+data_dir: {{ dolt_data_dir }}

--- a/roles/dolt_sql_server/templates/dolt-sql-server.service.j2
+++ b/roles/dolt_sql_server/templates/dolt-sql-server.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Dolt SQL Server
+After=network.target
+
+[Service]
+Type=simple
+User={{ dolt_service_user }}
+ExecStart={{ dolt_install_path }} sql-server --config={{ dolt_config_path }}
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/specs/008-dolt-sql-server-role/checklists/requirements.md
+++ b/specs/008-dolt-sql-server-role/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Dolt SQL Server Ansible Role
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass on first validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/008-dolt-sql-server-role/contracts/role-interface.md
+++ b/specs/008-dolt-sql-server-role/contracts/role-interface.md
@@ -1,0 +1,74 @@
+# Contract: Role Interface (`dolt_sql_server`)
+
+The role's public contract: how callers invoke it and what they may override.
+
+## Invocation
+
+```yaml
+# configure-linux-roles.yml (mandatory roles block)
+roles:
+  - podman
+  - claude_code
+  - tmux
+  - dolt_sql_server      # added by this feature
+```
+
+Or standalone:
+
+```yaml
+- hosts: linux
+  become: true
+  roles:
+    - role: dolt_sql_server
+```
+
+## Inputs (overridable variables)
+
+All inputs have safe defaults (see `data-model.md`). None are required from the
+caller. Commonly overridden:
+
+| Variable | Default | When to override |
+| --- | --- | --- |
+| `dolt_version` | `v2.0.8` | Pin a different Dolt release (`v`-prefixed upstream tag). |
+| `dolt_data_dir` | `/var/lib/dolt` | Relocate server data. |
+| `dolt_listen_port` | `3306` | Avoid a port clash (rare). |
+
+Overriding `dolt_listen_host` to a non-loopback value is rejected by an
+`assert` (FR-007).
+
+## Guarantees (postconditions)
+
+On success against a systemd host:
+
+1. `dolt` binary at `/usr/local/bin/dolt` reports the pinned version
+   (`dolt_version` with the leading `v` stripped) (FR-001).
+2. `dolt-sql-server.service` is **enabled** (starts on boot, FR-002) and
+   **active** (FR-002), with `Restart=always` (FR-003).
+3. Server listens on `127.0.0.1:3306` only — not on any external interface
+   (FR-007).
+4. Server accepts connections / is ready for `bd init --server` with no
+   further server-side configuration (FR-004).
+5. Re-running the role on an already-provisioned host makes no changes and does
+   not restart the running service (FR-005 / SC-003).
+
+## Version maintenance
+
+`dolt_version` is tracked by `playbooks/update-versions/` as a GitHub-release
+tool (`dolthub/dolt`). `query-versions.yml` reports it stale when a newer
+release exists; `perform-updates.yml` rewrites the pin in `defaults/main.yml`.
+The maintainer reviews `git diff roles/` and commits manually. See
+`docs/architecture/version-update-playbooks.md`.
+
+## Non-goals (FR-006)
+
+The role does NOT run `dolt init`, create databases, restore, or back up data,
+and does NOT configure any repository's `bd` settings.
+
+## Failure modes (Fail Loud — Principle XII)
+
+| Condition | Behaviour |
+| --- | --- |
+| `dolt_version` empty/undefined | `assert` fails before download. |
+| `dolt_listen_host` non-loopback | `assert` fails (protects FR-007). |
+| Tarball download fails | `get_url` fails the play (no silent fallback). |
+| Server not listening within `dolt_readiness_timeout` | `wait_for` + `assert` fail naming `host:port`. |

--- a/specs/008-dolt-sql-server-role/contracts/server-config.md
+++ b/specs/008-dolt-sql-server-role/contracts/server-config.md
@@ -1,0 +1,45 @@
+# Contract: Dolt SQL Server Config (`config.yaml`)
+
+Rendered from `templates/config.yaml.j2` to `{{ dolt_config_path }}`
+(default `/etc/dolt/config.yaml`). Defines the listener and storage contract
+required by FR-004 and FR-007.
+
+## Config contract
+
+```yaml
+listener:
+  host: {{ dolt_listen_host }}   # default 127.0.0.1 — loopback only
+  port: {{ dolt_listen_port }}   # default 3306
+data_dir: {{ dolt_data_dir }}    # default /var/lib/dolt
+```
+
+## Guarantees
+
+| Field | Value | Requirement |
+| --- | --- | --- |
+| `listener.host` | `127.0.0.1` (loopback) | FR-007 — not reachable off-host. Asserted loopback before render. |
+| `listener.port` | `3306` (default) | FR-004 — matches `bd init --server` default; no client override needed. |
+| `data_dir` | `/var/lib/dolt` | Role-owned, repo-agnostic storage. |
+
+## Authentication
+
+- Dolt auto-creates user `root` with **no password** on first run.
+- Acceptable because the listener is loopback-only (FR-007): no off-host
+  connection is possible.
+- The role provides no additional credentials or config (FR-004); it does not
+  run `dolt init` or create databases (FR-006).
+
+## Client contract (informational — performed by developer, not the role)
+
+A developer opts a repository in with a single command (US2, SC-004):
+
+```bash
+bd init --server          # uses default 127.0.0.1:3306, root, no password
+```
+
+Direct verification that storage landed in Dolt (US2 Independent Test):
+
+```bash
+dolt sql-client --host 127.0.0.1 --port 3306 --user root \
+  --execute "SHOW DATABASES;"      # repository prefix DB present
+```

--- a/specs/008-dolt-sql-server-role/contracts/systemd-service.md
+++ b/specs/008-dolt-sql-server-role/contracts/systemd-service.md
@@ -1,0 +1,51 @@
+# Contract: systemd Service (`dolt-sql-server.service`)
+
+Rendered from `templates/dolt-sql-server.service.j2`. Defines the boot and
+restart behaviour required by FR-002, FR-003, SC-002, SC-005.
+
+## Unit contract
+
+```ini
+[Unit]
+Description=Dolt SQL Server
+After=network.target
+
+[Service]
+Type=simple
+User={{ dolt_service_user }}
+ExecStart={{ dolt_install_path }} sql-server --config={{ dolt_config_path }}
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Behavioural guarantees
+
+| Directive | Requirement satisfied |
+| --- | --- |
+| `WantedBy=multi-user.target` + unit `enabled` | Starts automatically on every boot, including first boot after provisioning (FR-002, SC-002). |
+| `Restart=always`, `RestartSec=2` | Service restarts after an unexpected stop/crash (FR-003, SC-005). |
+| `User={{ dolt_service_user }}` | Runs unprivileged (least privilege). |
+| `ExecStart ... --config` | Loopback-only listener via the config file (FR-007). |
+
+## Lifecycle management (Ansible)
+
+- `ansible.builtin.systemd_service`: `daemon_reload: true` (on change),
+  `enabled: true`, `state: started`.
+- Applied only where `ansible_facts['service_mgr'] == 'systemd'` (D6). In a
+  non-systemd container the unit file is still rendered for inspection, but
+  enable/start are skipped (explicit environment guard).
+- Config or unit changes notify a handler: `daemon_reload` → restart. An
+  unchanged re-run performs no restart (FR-005, SC-003).
+
+## Validation
+
+- **Molecule (container)**: assert unit file exists and contains
+  `Restart=always` and `WantedBy=multi-user.target`. Enable/start not exercised
+  (no PID1 systemd).
+- **VM (Vagrant/cloud, Principle III)**: `systemctl is-enabled` →
+  `enabled`; `systemctl is-active` → `active`; reboot → service active before
+  login; `systemctl kill` → service auto-restarts. Procedure in
+  `quickstart.md`.

--- a/specs/008-dolt-sql-server-role/data-model.md
+++ b/specs/008-dolt-sql-server-role/data-model.md
@@ -1,0 +1,73 @@
+# Phase 1 Data Model: Dolt SQL Server Ansible Role
+
+This role configures infrastructure, not application data. The "entities" are
+the role's configuration surface (variables) and the on-host artefacts it
+manages. Spec Key Entities map to the managed artefacts below.
+
+## Role variables (`defaults/main.yml`)
+
+| Variable | Type | Default | Validation | Purpose |
+| --- | --- | --- | --- | --- |
+| `dolt_version` | string | `v2.0.8` | non-empty; `v`-prefixed upstream tag | Pinned Dolt release to install (D2). `v`-prefixed (GitHub `tag_name`) — embeds in download URL; version assert strips `^v`. Tracked by `playbooks/update-versions/` (D8). |
+| `dolt_install_path` | path | `/usr/local/bin/dolt` | absolute path | Installed binary location. |
+| `dolt_listen_host` | string | `127.0.0.1` | MUST be a loopback address | Listener bind address (FR-007). Asserted loopback. |
+| `dolt_listen_port` | int | `3306` | 1–65535 | Listener port; default matches `bd init --server`. |
+| `dolt_data_dir` | path | `/var/lib/dolt` | absolute path | Server data directory; role-owned, repo-agnostic. |
+| `dolt_config_dir` | path | `/etc/dolt` | absolute path | Holds rendered `config.yaml`. |
+| `dolt_config_path` | path | `{{ dolt_config_dir }}/config.yaml` | absolute path | `--config` argument. |
+| `dolt_service_user` | string | `dolt` | valid system username | Unprivileged user running the service. |
+| `dolt_service_name` | string | `dolt-sql-server` | systemd unit name | Unit + handler reference. |
+| `dolt_readiness_timeout` | int (s) | `30` | > 0 | `wait_for` bound on port readiness (D5). |
+
+### Validation rules (Fail Loud — Principle XII)
+
+- `assert` `dolt_version` is defined and non-empty before download.
+- `assert` `dolt_listen_host` resolves to a loopback address (`127.0.0.0/8` or
+  `localhost`) — guards FR-007 against accidental `0.0.0.0`.
+- `assert` `dolt_listen_port` is an integer in range.
+- After start (where systemd present) or after smoke-launch (container),
+  `wait_for` `{{ dolt_listen_host }}:{{ dolt_listen_port }}` then `assert`
+  reachable; failure message names host:port.
+
+## Managed artefacts (state transitions)
+
+### 1. Dolt binary
+
+- **Absent → Present**: download tarball for `ansible_facts['architecture']`,
+  extract, place at `dolt_install_path` (mode `0755`). Guarded by `stat` +
+  version check.
+- **Present (correct version) → Present**: no-op (idempotent).
+- **Present (wrong version) → Present (pinned)**: re-download/replace.
+
+Maps to spec entity **VM Provisioning** (install software) and FR-001.
+
+### 2. Server config (`/etc/dolt/config.yaml`)
+
+- **Absent → Present**: rendered from `config.yaml.j2` with loopback listener +
+  data_dir.
+- **Changed**: re-rendered → notifies restart handler.
+- **Unchanged**: no-op, no restart (FR-005 / SC-003).
+
+Maps to spec entity **Shared Write Service** (configuration) and FR-007.
+
+### 3. Service user + data dir
+
+- `dolt` system user created (`system: true`, no login shell).
+- `dolt_data_dir` and `dolt_config_dir` created, owned by `dolt`.
+
+### 4. systemd unit (`/etc/systemd/system/dolt-sql-server.service`)
+
+- **Absent → Present + enabled + started**: rendered from
+  `dolt-sql-server.service.j2`; `daemon_reload`; `enabled: true`;
+  `state: started`. Only where `service_mgr == 'systemd'` (D6).
+- **Changed**: re-render → `daemon_reload` + restart via handler.
+- **Unchanged**: no-op, running service untouched (FR-005).
+
+Maps to spec entity **Shared Write Service** (lifecycle) and FR-002/FR-003.
+
+## Out-of-model (explicitly NOT managed — FR-006)
+
+- Databases / `dolt init` — owned by `bd bootstrap`.
+- Data restore — owned by `bd dolt pull` / `bd bootstrap`.
+- Data backup — owned by `bd dolt push`.
+- Per-repository `bd init --server` configuration — developer opt-in (US2).

--- a/specs/008-dolt-sql-server-role/plan.md
+++ b/specs/008-dolt-sql-server-role/plan.md
@@ -1,0 +1,135 @@
+# Implementation Plan: Dolt SQL Server Ansible Role
+
+**Branch**: `008-dolt-sql-server-role` | **Date**: 2026-05-30 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/008-dolt-sql-server-role/spec.md`
+
+## Summary
+
+Provide a shared, concurrent-write task-tracking backend on each ephemeral
+agent VM by installing the Dolt binary and running `dolt sql-server` as a
+systemd service that starts on every boot, binds to loopback only, and
+restarts on failure. The role installs and starts the server only; it does
+not initialise databases, restore, or back up data (those belong to
+`bd bootstrap` / `bd dolt push` at session start/end). Delivered as a new
+role `roles/dolt_sql_server` wired into `configure-linux-roles.yml`, with a
+Molecule scenario covering the containerisable surface and a Vagrant/cloud-VM
+procedure for the systemd-on-boot behaviour that a plain container cannot
+exercise. The pinned `dolt_version` is registered with the existing
+version-update playbooks (`playbooks/update-versions/`) as a GitHub-release
+tool so the pin does not silently drift behind upstream security releases.
+
+## Technical Context
+
+**Language/Version**: YAML — Ansible 2.19+ (`min_ansible_version: 2.19`)
+**Primary Dependencies**: `ansible.builtin` (apt, get_url, unarchive, template,
+systemd_service, user, file, stat, wait_for, assert); no new Galaxy
+collections required
+**Storage**: Dolt SQL server data directory on the VM (e.g.
+`/var/lib/dolt`); ephemeral — recreated each VM, hydrated by `bd bootstrap`
+**Testing**: Molecule (podman driver, `docker.io/library/ubuntu:24.04`) for
+the containerisable surface; Vagrant/cloud VM for systemd-on-boot per
+Constitution Principle III
+**Target Platform**: Ubuntu Linux (jammy, noble) on AWS EC2 / Hetzner /
+local Vagrant; arch amd64 and arm64
+**Project Type**: Ansible role (single-purpose infrastructure automation)
+**Performance Goals**: Server ready within the normal VM boot sequence
+(SC-002); concurrent writes from parallel sessions with zero lock-contention
+failures (SC-001) — guaranteed architecturally by server mode, not benchmarked
+**Constraints**: Loopback-only listener (FR-007); idempotent re-provisioning
+without service disruption (FR-005); no credentials/config beyond what the
+role provides (FR-004); install + service only — no DB init/restore/backup
+(FR-006)
+**Scale/Scope**: One server per VM, single OS user, single localhost port
+(3306). Not a remote/shared server.
+**Version maintenance**: `dolt_version` pinned in `defaults/main.yml` and
+tracked by `playbooks/update-versions/` — GitHub-release source
+(`dolthub/dolt`), reusing `tasks/fetch-github-release.yml`; version-only (no
+checksum), matching the gitmux / Nerd Fonts precedent in
+`docs/architecture/version-update-playbooks.md`.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+| --- | --- | --- |
+| I. Idempotency (NON-NEGOTIABLE) | PASS | Pinned-version tarball install guarded by `stat`/`creates`; `template` + `systemd_service` are natively idempotent; no `blockinfile` newline params. Re-run does not disrupt running service (FR-005). |
+| II. Role-First Organisation | PASS | Standalone role `roles/dolt_sql_server`; playbook only orchestrates. Molecule scenario in `molecule/default/`. Systemd-on-boot validated on VM (Principle III) — see Complexity Tracking. |
+| III. Test Locally Before Cloud | PASS | `molecule test` covers install/config/unit/loopback + functional server smoke test; VM procedure in quickstart covers systemd boot/restart. |
+| IV. Simplicity (YAGNI) | PASS | Single server, single user, defaults only. No remote-server, no Dolt Hub, no multi-DB provisioning. Version pinned as one variable. |
+| V. Conventional Commits & Traceability | PASS | `commit` skill invoked before each commit. |
+| VI. Markdown Quality | PASS | `format-markdown` run at task close. |
+| VII. Structured Problem Solving | PASS | `fix-problem` invoked on obstacles. |
+| VIII. No Untracked Technical Debt | PASS | Findings tracked as blocking issues at source priority. |
+| IX. CI/CD Pipeline Security | N/A | No CI workflow or artefact publish introduced by this role. |
+| X. No External-System References | PASS | No beads IDs in role files, templates, or these specs. |
+| XI. Avoid Duplication (DRY) | PASS | Reuses canonical Molecule scaffold; config/unit values centralised in `defaults/main.yml`; no copied logic. Version-update integration reuses the parametrized `fetch-github-release.yml` (no new fetch logic) per FR-006 of the version-update design. |
+| XII. Fail Loud | PASS | `assert` validates required vars and server readiness (`wait_for` the loopback port); no `default('')`/`ignore_errors` masking; systemd guard is an explicit environment condition, not a silent skip of a required value. |
+
+**Initial gate: PASS.** One containerisation limitation justified in
+Complexity Tracking (systemd-on-boot needs PID1 systemd, unavailable in the
+canonical plain container).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-dolt-sql-server-role/
+├── plan.md              # This file (/speckit.plan output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   ├── systemd-service.md
+│   ├── server-config.md
+│   └── role-interface.md
+├── checklists/
+│   └── requirements.md  # pre-existing
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+roles/dolt_sql_server/
+├── README.md                     # role usage + boundary
+├── defaults/main.yml             # dolt_version, port, host, data_dir, user, paths
+├── meta/main.yml                 # galaxy_info (namespace: wonderbird), platforms
+├── handlers/main.yml             # restart dolt-sql-server (daemon_reload + restart)
+├── tasks/main.yml                # install binary → config → unit → enable/start
+├── templates/
+│   ├── config.yaml.j2            # dolt sql-server config (loopback listener)
+│   └── dolt-sql-server.service.j2 # systemd unit (Restart=always)
+└── molecule/default/
+    ├── molecule.yml              # canonical (podman, ubuntu:24.04)
+    ├── prepare.yml               # canonical bootstrap
+    ├── converge.yml              # apply role
+    └── verify.yml                # assert install/config/unit/loopback + smoke test
+
+configure-linux-roles.yml         # add `dolt_sql_server` to roles list
+
+playbooks/update-versions/
+├── query-versions.yml            # add Dolt: slurp defaults, fetch, report, fail-if-stale
+└── perform-updates.yml           # add Dolt: fetch + replace dolt_version
+# tasks/fetch-github-release.yml reused as-is (github_repo: dolthub/dolt)
+
+docs/architecture/version-update-playbooks.md  # add Dolt row to tracked-tools table
+```
+
+**Structure Decision**: Standard Ansible role layout produced by
+`scripts/new-role.sh dolt_sql_server`, matching `roles/podman`. The role is
+added to the mandatory roles block in `configure-linux-roles.yml` (alongside
+`podman`, `claude_code`, `tmux`) so it runs during base VM provisioning
+(FR-001). `templates/` holds the two rendered artefacts (server config and
+systemd unit); `handlers/` performs `daemon_reload` + restart on config
+change without disrupting an unchanged service (FR-005). Separately, the two
+existing version-update playbooks gain a Dolt entry (detect + apply) and the
+version-update architecture doc gains a tracked-tools row; the GitHub-release
+fetch task file is reused unchanged.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --- | --- | --- |
+| Systemd-on-boot (FR-002/FR-003) validated on a Vagrant/cloud VM rather than in the Molecule container | The canonical Molecule image (`ubuntu:24.04`, no PID1 systemd) cannot exercise `systemctl enable`/start-on-boot/auto-restart. Server install, config, unit-file rendering, loopback binding, and a direct functional smoke test ARE containerisable and remain in Molecule. | (a) Switching the role's `molecule.yml` to a privileged systemd image is forbidden — `molecule.yml` is canonical and changing it per-role (or globally) degrades every other role's scenario for one role's need. (b) Mocking systemd would not validate the real boot behaviour the requirement is about. Principle III explicitly authorises the VM fallback for the non-containerisable slice. |

--- a/specs/008-dolt-sql-server-role/quickstart.md
+++ b/specs/008-dolt-sql-server-role/quickstart.md
@@ -1,0 +1,108 @@
+# Quickstart: Dolt SQL Server Ansible Role
+
+How to build, test, and validate the `dolt_sql_server` role.
+
+## Prerequisites
+
+Project `.venv` with Molecule (re-create whenever absent — it is git-ignored):
+
+```bash
+# from repo root
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+ansible-galaxy install -r requirements.yml
+```
+
+## Scaffold the role
+
+```bash
+bash scripts/new-role.sh dolt_sql_server
+```
+
+Then customise `meta/main.yml` (`role_name: dolt_sql_server`), `defaults/`,
+`tasks/`, `templates/`, `handlers/`, and the Molecule `converge.yml` /
+`verify.yml`. Do not hand-edit `molecule.yml` or `prepare.yml` (canonical).
+
+## Local validation — Molecule (containerisable surface)
+
+```bash
+cd roles/dolt_sql_server
+molecule test
+```
+
+Covers create → prepare → converge → idempotence → verify → destroy. Asserts:
+
+- `dolt --version` reports the pinned `dolt_version` (FR-001).
+- `/etc/dolt/config.yaml` has `host: 127.0.0.1` (FR-007).
+- `dolt-sql-server.service` unit present with `Restart=always` and
+  `WantedBy=multi-user.target`.
+- **Functional smoke test**: server launched directly from the config binds to
+  `127.0.0.1:3306` (verified via `ss -tlnp`, asserted NOT `0.0.0.0`) and
+  answers `SELECT 1` (FR-004, FR-007).
+- Idempotence: second converge reports no changes (FR-005).
+
+The two podman schema warnings are expected and acceptable.
+
+## VM validation — systemd boot & restart (Principle III)
+
+The plain Molecule container has no PID1 systemd, so FR-002 (start on boot)
+and FR-003 (auto-restart) are validated on a Vagrant/cloud VM. Follow
+`CONTRIBUTING.md` to isolate the role in `configure-linux-roles.yml`, then:
+
+```bash
+# 1. Provision a fresh local VM and run the playbook (see CONTRIBUTING.md)
+
+# 2. Service enabled + active after provisioning (FR-002, SC-002)
+systemctl is-enabled dolt-sql-server   # → enabled
+systemctl is-active  dolt-sql-server   # → active
+
+# 3. Loopback-only binding (FR-007)
+ss -tlnp | grep 3306                   # bound to 127.0.0.1:3306, not 0.0.0.0
+
+# 4. Survives reboot, ready before login (FR-002, SC-002)
+sudo reboot
+# after reconnect:
+systemctl is-active dolt-sql-server    # → active
+
+# 5. Auto-restart after crash (FR-003, SC-005)
+sudo systemctl kill -s SIGKILL dolt-sql-server
+sleep 3
+systemctl is-active dolt-sql-server    # → active (restarted)
+
+# 6. Idempotent re-provision does not disrupt the service (FR-005, SC-003)
+#    re-run the playbook; confirm no service restart and changed=0 for the role
+```
+
+## Developer opt-in (post-provisioning, not part of the role — US2)
+
+```bash
+cd /path/to/git/repo            # has >=1 commit
+bd init --server                # connects to 127.0.0.1:3306
+bd create --title="..." --type=task
+dolt sql-client --host 127.0.0.1 --port 3306 --user root \
+  --execute "SHOW DATABASES;"   # repo-prefix DB confirms server-backed storage
+```
+
+## Wire into provisioning
+
+Add `dolt_sql_server` to the mandatory `roles:` block of
+`configure-linux-roles.yml` so it runs during base VM setup (FR-001).
+
+## Keep the version pin current
+
+`dolt_version` is tracked by the version-update playbooks (GitHub-release
+source `dolthub/dolt`). Detect drift and apply updates:
+
+```bash
+# Report stale pins (exits non-zero if any tool, incl. Dolt, is stale)
+ansible-playbook playbooks/update-versions/query-versions.yml
+
+# Rewrite pins in role defaults (no commit created)
+ansible-playbook playbooks/update-versions/perform-updates.yml
+git diff roles/dolt_sql_server/defaults/main.yml   # review, then commit
+```
+
+Wiring this in requires adding a Dolt entry to both playbooks and a row to
+`docs/architecture/version-update-playbooks.md`; the GitHub-release fetch task
+is reused unchanged.

--- a/specs/008-dolt-sql-server-role/research.md
+++ b/specs/008-dolt-sql-server-role/research.md
@@ -1,0 +1,223 @@
+# Phase 0 Research: Dolt SQL Server Ansible Role
+
+All NEEDS CLARIFICATION items from Technical Context resolved below.
+
+## D1 — Server mode vs embedded mode (Branch A vs Branch B)
+
+**Decision**: Implement server mode (Branch B): a system-wide `dolt sql-server`
+as a systemd service.
+
+**Rationale**: A Step-0 spike showed embedded Dolt already serialised 10/10
+concurrent writes across sibling worktrees on the developer machine (Branch A),
+because beads resolves `.beads/` to the git root so worktrees share one DB.
+However, that result was **never re-confirmed on a fresh VM** (no VM was
+available), so Branch A remained provisional. The feature spec (the
+authoritative input to this plan) selects the server-mode guarantee: FR-001..
+FR-007 require an installed binary, an auto-starting systemd service, loopback
+binding, and readiness for `bd init --server`. Server mode removes the
+dependence on a single shared embedded DB file and makes the concurrent-write
+guarantee architectural rather than incidental.
+
+**Alternatives considered**: Branch A (embedded only, no role) — rejected as
+provisional/unconfirmed on fresh VMs and not what the spec mandates. If a fresh
+VM later proves embedded mode sufficient, the role can be retired; that is a
+separate decision outside this plan.
+
+## D2 — Dolt binary installation method
+
+**Decision**: Download the architecture-specific release tarball
+(`dolt-linux-amd64.tar.gz` / `dolt-linux-arm64.tar.gz`) for a **pinned**
+version via `ansible.builtin.get_url`, extract with `ansible.builtin.unarchive`,
+and place the `dolt` binary at `/usr/local/bin/dolt`. Architecture is selected
+from `ansible_facts['architecture']` (`x86_64` → amd64, `aarch64` → arm64).
+Guard every step on a `stat` of the installed binary and the target version so
+re-runs are no-ops.
+
+**Rationale**: A pinned tarball is deterministic and idempotent — the
+constitution favours reproducibility (Principle I) and loud, predictable
+behaviour (Principle XII). The upstream `install.sh` always fetches `latest`,
+which is non-deterministic across VM rebuilds and would silently upgrade the
+server. The tarball path lets the role assert the exact version it installed.
+`dolt` is a single static Go binary (no runtime deps), so extraction + placement
+is sufficient.
+
+**Alternatives considered**:
+
+- Official `install.sh` piped to bash — rejected: pulls `latest`
+  (non-deterministic), runs an opaque remote script (supply-chain + Fail-Loud
+  concerns).
+- `apt` package — rejected: Dolt is not in Ubuntu repos.
+
+**Key facts**: latest release at planning time is `v2.0.8`; binaries published
+for linux amd64 and arm64; install target `/usr/local/bin`. Pin the version in
+`defaults/main.yml` as `dolt_version`.
+
+## D3 — `dolt sql-server` configuration (loopback-only)
+
+**Decision**: Render `config.yaml` from a template and start the server with
+`dolt sql-server --config=<path>`. Bind to loopback only:
+
+```yaml
+listener:
+  host: 127.0.0.1
+  port: 3306
+data_dir: /var/lib/dolt
+```
+
+**Rationale**: Satisfies FR-007 (localhost only) directly — `host: 127.0.0.1`
+means the listener never accepts off-host connections. Port 3306 is Dolt's
+default MySQL-compatible port and what `bd init --server` expects by default,
+so no extra client config is needed (FR-004). `data_dir` under `/var/lib/dolt`
+is a conventional, role-owned location separate from any repo.
+
+**Authentication**: Dolt creates a default `root` user with **no password** on
+first run; auth is managed via SQL (`CREATE USER`/`GRANT`), not config fields.
+Loopback-only binding makes the no-password root acceptable for a single-user
+agent VM (no off-host reachability). The role provides no credentials beyond
+this default (FR-004); it does not run `dolt init` or create databases (FR-006).
+
+**Alternatives considered**: `0.0.0.0` bind — rejected, violates FR-007.
+Non-default port — rejected, would force every `bd init --server` to carry
+custom host/port (YAGNI, Principle IV).
+
+## D4 — systemd unit design
+
+**Decision**: Install a `dolt-sql-server.service` unit, `enabled: true`,
+`state: started`, run as a dedicated unprivileged system user `dolt` with
+`WorkingDirectory`/`data_dir` it owns. Key directives:
+
+```ini
+[Unit]
+Description=Dolt SQL Server
+After=network.target
+
+[Service]
+Type=simple
+User=dolt
+ExecStart=/usr/local/bin/dolt sql-server --config=/etc/dolt/config.yaml
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**Rationale**: `WantedBy=multi-user.target` + `enabled` gives auto-start on
+every boot, including the first boot after provisioning (FR-002). `Restart=
+always` gives crash recovery (FR-003, SC-005). A dedicated `dolt` system user
+follows least privilege. Config changes notify a handler that runs
+`daemon_reload` then restarts only when the unit/config actually changed, so an
+unchanged re-provision leaves the running service untouched (FR-005, SC-003).
+
+**Alternatives considered**: user-level (`--user`) service with lingering —
+rejected: more moving parts (linger enablement) for no benefit on a
+single-purpose VM (YAGNI). `Type=notify` — rejected: Dolt does not implement
+sd_notify; `simple` + a `wait_for` readiness gate is sufficient.
+
+## D5 — Readiness verification (Fail Loud)
+
+**Decision**: After starting the service, gate readiness with
+`ansible.builtin.wait_for` on `127.0.0.1:3306` (bounded timeout), and `assert`
+the port is listening. In Molecule's functional smoke test, additionally run a
+trivial `SELECT 1` against the loopback listener and assert success.
+
+**Rationale**: FR-004/SC-002 require the server be ready to accept
+`bd init --server` immediately after provisioning. A bounded `wait_for` + assert
+fails loudly (Principle XII) with the host:port in the message if the server
+never comes up, rather than allowing a later silent connection failure.
+
+## D6 — Molecule strategy under the canonical plain container
+
+**Decision**: Keep the canonical `molecule.yml` (podman, `ubuntu:24.04`, no
+PID1 systemd). Molecule validates the containerisable surface:
+
+1. `dolt` binary installed and reports the pinned version (FR-001).
+2. `/etc/dolt/config.yaml` rendered with `host: 127.0.0.1` (FR-007).
+3. `dolt-sql-server.service` unit file present and well-formed.
+4. **Functional smoke test**: launch `dolt sql-server --config` directly (not
+   via systemd) in the container, `wait_for` the port, run `SELECT 1`, and
+   assert the listener is bound to `127.0.0.1` and **not** `0.0.0.0`
+   (inspect `ss -tlnp`). This exercises real install + config + loopback
+   binding (FR-001, FR-004, FR-007) without PID1 systemd.
+
+The systemd `enable`/start tasks in the role are guarded on systemd presence
+(`ansible_facts['service_mgr'] == 'systemd'`). In the plain container they are
+skipped (explicit environment condition, documented — not a silent skip of a
+required value); on a real VM `service_mgr` is `systemd` and they run.
+
+**FR-002 (start on boot) and FR-003 (auto-restart)** require PID1 systemd and
+are validated on a Vagrant/cloud VM per Constitution Principle III, with the
+procedure documented in `quickstart.md`.
+
+**Rationale**: The canonical scaffold is shared and must not be degraded for
+one role (DRY, Principle XI; molecule-testing skill rule). Splitting validation
+— containerisable parts in Molecule, boot behaviour on a VM — is exactly the
+fallback Principle III authorises. The functional smoke test still proves the
+binary and loopback config genuinely work, so the container test is meaningful,
+not a stub.
+
+**Alternatives considered**: privileged systemd container image — rejected,
+requires changing canonical `molecule.yml` (forbidden per-role; harmful
+globally). Skipping functional validation and only checking file presence —
+rejected, would not prove the server actually starts or binds correctly.
+
+## D7 — Wiring into provisioning
+
+**Decision**: Add `dolt_sql_server` to the mandatory `roles:` block of
+`configure-linux-roles.yml`, after `podman`/`claude_code`/`tmux`. No tag.
+
+**Rationale**: FR-001 requires install as part of standard base setup; the
+mandatory block runs on every Linux provision. The role is container-friendly
+for its install/config parts and degrades safely where systemd is absent, so it
+needs no `not-supported-on-vagrant-arm64` tag.
+
+## D8 — Version-pin maintenance (no silent drift)
+
+**Decision**: Register `dolt_version` with the existing version-update
+playbooks (`playbooks/update-versions/`). Dolt is a GitHub-release tool
+(`dolthub/dolt`), so reuse the parametrized `tasks/fetch-github-release.yml`
+with `github_repo: dolthub/dolt`. Version-only pin (no checksum), matching the
+gitmux / Nerd Fonts precedent. Concrete changes (implemented in the tasks
+phase, not this plan):
+
+- `query-versions.yml`: slurp `roles/dolt_sql_server/defaults/main.yml`,
+  extract `current_dolt_version`, `include_tasks fetch-github-release.yml`
+  with `github_repo: dolthub/dolt`, save `fetched_dolt_tag`, add a status
+  report, and extend the fail-if-stale condition.
+- `perform-updates.yml`: fetch the same tag and
+  `ansible.builtin.replace` the `dolt_version` line in the role defaults.
+- `docs/architecture/version-update-playbooks.md`: add a Dolt row to the
+  tracked-tools table (Role `dolt_sql_server`, version_key `dolt_version`,
+  checksum_key —, source GitHub Releases API `dolthub/dolt`).
+
+**Pin format**: store the upstream tag verbatim, `dolt_version: "v2.0.8"`
+(the `tag_name` returned by the GitHub API, `v`-prefixed like
+`tmux_gitmux_version: "v0.11.5"`). The release-download URL embeds the tag,
+so the `v` is required for the install URL. `dolt --version` prints the
+number without the `v`, so Molecule's version assertion compares against
+`dolt_version | regex_replace('^v', '')`.
+
+**Rationale**: The version-update design (FR-001/FR-002) exists precisely so
+pins do not drift behind upstream security releases. A new pinned tool that is
+not registered would be invisible to `query-versions.yml` and silently rot —
+the exact failure the design prevents. Reusing `fetch-github-release.yml`
+satisfies FR-006 (no duplicated fetch logic) and Principle XI (DRY).
+
+**Alternatives considered**:
+
+- Add a checksum (sha256) pin + verified `get_url` — rejected for now: no
+  GitHub-release tool in the repo carries a checksum_key, and the update
+  tooling has no GitHub-asset checksum fetch path. Adding one would extend the
+  shared fetch task for a single tool (YAGNI, Principle IV). Loopback-only
+  exposure and HTTPS download keep risk acceptable; revisit if a checksum
+  fetch path is added for the GitHub-release class generally.
+- Leave `dolt_version` untracked — rejected: reintroduces silent drift,
+  contradicting the version-update design's reason for existing.
+
+## Open follow-ups (tracked as issues, not blockers of this plan)
+
+- Fresh-VM re-confirmation of Branch A vs Branch B (was provisional in the
+  spike). If embedded mode is proven sufficient on a fresh VM, revisit whether
+  the role is still required.
+- Post-merge data migration (`bd backup sync` + `bd backup restore --force`)
+  is a session/runtime action, out of role scope (FR-006).

--- a/specs/008-dolt-sql-server-role/spec.md
+++ b/specs/008-dolt-sql-server-role/spec.md
@@ -37,8 +37,12 @@ agent connects to the shared service without any manual steps.
 1. **Given** a VM provisioned for the first time, **When** the VM completes its boot
    sequence, **Then** the shared write service is running and accepting connections
    before any agent session can begin.
-2. **Given** a VM whose shared write service crashed, **When** the VM reboots,
-   **Then** the service restarts automatically.
+2. **Given** a running shared write service, **When** the service process is
+   killed (SIGKILL), **Then** the service restarts automatically within a few
+   seconds without any operator action (FR-003).
+3. **Given** a VM where the shared write service is installed and enabled,
+   **When** the VM reboots, **Then** the service is active and accepting
+   connections again before any agent session can begin (FR-002).
 
 ---
 

--- a/specs/008-dolt-sql-server-role/spec.md
+++ b/specs/008-dolt-sql-server-role/spec.md
@@ -1,0 +1,177 @@
+# Feature Specification: Dolt SQL Server Ansible Role
+
+**Feature Branch**: `008-dolt-sql-server-role`
+**Created**: 2026-05-30
+**Status**: Draft
+**Input**: User description: "beads task 1l6"
+
+## Feature Goal
+
+The motivating outcome is that all parallel agent sessions on the same VM can write
+task-tracking data simultaneously without any write failing due to lock contention.
+
+This outcome cannot be tested directly in isolation — write collisions are probabilistic
+and rare under normal load. Instead, it is guaranteed architecturally: if a shared
+write service is running (US1) and developers have opted their repositories in (US2),
+concurrent writes succeed by design. The user stories below specify the concrete,
+testable conditions that together deliver this guarantee.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - SQL Server Starts Automatically on VM Boot (Priority: P1)
+
+Each VM is created fresh and destroyed regularly. The shared write service must be
+running before any agent session starts, without manual intervention after VM creation.
+
+After a VM is provisioned once, the shared write service starts automatically on every
+boot — including the initial boot after provisioning — without operator action.
+
+**Why this priority**: Auto-startup is the foundational prerequisite. Without it,
+the shared service is absent when agents start, and no other story can deliver value.
+
+**Independent Test**: Provision a VM, reboot it, start an agent session. Verify the
+agent connects to the shared service without any manual steps.
+
+**Acceptance Scenarios**:
+
+1. **Given** a VM provisioned for the first time, **When** the VM completes its boot
+   sequence, **Then** the shared write service is running and accepting connections
+   before any agent session can begin.
+2. **Given** a VM whose shared write service crashed, **When** the VM reboots,
+   **Then** the service restarts automatically.
+
+---
+
+### User Story 2 - Developer Initializes Repository with Dolt Backend (Priority: P2)
+
+A developer who wants to use the running Dolt SQL server for task tracking in their git
+repository runs `bd init --server` once in that repository. After initialization, tasks
+created in the repository are stored in the Dolt server. This is an explicit
+per-repository opt-in; only developers who choose server-backed task tracking need this
+step.
+
+**Why this priority**: Without this step no repository connects to the server. This is
+the opt-in that activates the feature for actual use in a project.
+
+**Independent Test**:
+
+1. Create a new directory, run `git init`, add a file and commit.
+2. Run `bd init --server`.
+3. Create a task with `bd create`.
+4. Query the Dolt server directly to verify the task record exists in the Dolt database
+   for the repository's prefix — proving storage landed in Dolt, not an embedded fallback.
+
+**Acceptance Scenarios**:
+
+1. **Given** a git repository with at least one commit and the Dolt server running,
+   **When** `bd init --server` is run, **Then** beads initializes successfully with the
+   Dolt server as its backend.
+2. **Given** a repository initialized with `bd init --server`, **When** a task is
+   created via `bd create`, **Then** querying the Dolt server directly shows the task
+   present in the Dolt database for that repository's prefix.
+3. **Given** a repository initialized with `bd init --server`, **When** the Dolt server
+   is queried, **Then** a dedicated database exists for the repository's prefix,
+   confirming server-backed storage is active.
+
+---
+
+### Edge Cases
+
+- What if provisioning is re-run on a VM where the service is already running? The
+  re-run must complete without disrupting or duplicating the running service.
+- What if `bd init --server` (new repo configuration) or `bd bootstrap` (restoring
+  tasks in a repo already configured with server backend) is run when the server is
+  not running? Both commands must fail with a clear, actionable error. Silent fallback
+  to embedded mode is not acceptable in either case.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The VM provisioning process MUST install the Dolt database binary on
+  each new VM as part of standard base setup.
+- **FR-002**: The shared write service MUST start automatically when the VM boots,
+  with no operator action required after provisioning.
+- **FR-003**: The shared write service MUST restart automatically if it stops
+  unexpectedly.
+- **FR-004**: The Dolt SQL server MUST be ready to accept `bd init --server`
+  connections immediately after provisioning completes, without requiring credentials
+  or configuration beyond what the role provides.
+- **FR-005**: The provisioning process MUST be idempotent — re-running it on a VM
+  where the service is already installed and running MUST complete without errors
+  and MUST NOT disrupt or duplicate the running service.
+- **FR-006**: The provisioning process MUST NOT initialize task-tracking databases
+  or restore backup data — those responsibilities belong to the session startup
+  process.
+- **FR-007**: The shared write service MUST accept connections from localhost only
+  (loopback interface). It MUST NOT be reachable from other hosts on the network.
+
+### Key Entities
+
+- **Shared Write Service**: Local database service accepting concurrent writes from
+  multiple agent sessions on the same VM. Runs continuously from VM boot until
+  VM destruction.
+- **Repository Initialization**: A one-time, per-repository developer action
+  (`bd init --server`) that configures the task-tracking tool to use the Dolt SQL
+  server as its backend. The role does not perform this step; it only ensures the
+  server is ready to accept it.
+- **VM Provisioning**: One-time setup process run when a new VM is created.
+  Responsible for installing software and configuring services; does not configure
+  any specific repository.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All parallel agent sessions on a provisioned VM write task-tracking
+  data simultaneously with zero failures due to write-lock contention.
+- **SC-002**: Shared write service is running and ready within the VM's normal boot
+  sequence, before any agent session begins.
+- **SC-003**: Re-provisioning a VM that already has the service installed completes
+  without errors and without interrupting active agent sessions.
+- **SC-004**: A developer can initialize any git repository to use the Dolt SQL
+  server backend by running a single command after provisioning, with no additional
+  server-side configuration required.
+- **SC-005**: A crashed shared write service recovers automatically on VM reboot
+  without operator intervention.
+
+## Assumptions
+
+- VM provisioning is performed by existing base-setup automation; this feature
+  extends that process.
+- Shared write service is local to each VM — not shared across multiple VMs.
+- Database initialization and data restore/backup remain the responsibility of
+  session startup and shutdown processes respectively; not this provisioning feature.
+- Task-tracking tool supports connecting to the Dolt SQL server via `bd init --server`;
+  no changes to the tool itself are required.
+- Repository configuration is a per-repository developer opt-in (`bd init --server`);
+  the role does not configure any repository automatically.
+
+## Clarifications
+
+### Session 2026-05-30
+
+- Q: US1 is the hoped-for outcome but cannot be tested directly (collisions are
+  probabilistic). How should this be represented? → A: Converted US1 to a
+  "Feature Goal" section above user stories. The goal is verified architecturally
+  through US1 + US2 together, not by a direct collision test. Former US2 → US1
+  (P1), former US3 → US2 (P2).
+- Q: Should the shared write service accept connections from localhost only or
+  from all network interfaces? → A: Localhost only (loopback interface only;
+  not reachable from other hosts). Added FR-007.
+- Q: Does the Ansible role configure repository task-tracking settings, or only
+  install and start the server? → A: Role = server only. `bd init --server` is a
+  developer one-time action per repository; the role has no knowledge of any
+  specific repo. Invalidated old FR-004 and SC-004.
+- Q: How should FR-004 and SC-004 be updated given that `bd init --server` is a
+  manual developer step? → A: FR-004 replaced with server readiness for
+  `bd init --server`. SC-004 replaced with "single command to init any repo,
+  no extra server-side setup required."
+- Q: Should US2 acceptance verify task presence by querying Dolt directly or via
+  beads round-trip? → A: Direct Dolt query — only this proves storage landed in
+  Dolt rather than silently falling back to embedded mode.
+- Q: First edge case ("agent session detects missing server") is redundant and
+  hard to test — what are the real entry points? → A: Removed vague "agent session"
+  edge cases. Real entry points are `bd init --server` (new repo) and `bd bootstrap`
+  (cloned repo with existing server config). Both must fail loudly when server is
+  not running. Edge Cases section updated accordingly.

--- a/specs/008-dolt-sql-server-role/spec.md
+++ b/specs/008-dolt-sql-server-role/spec.md
@@ -20,23 +20,25 @@ testable conditions that together deliver this guarantee.
 
 ### User Story 1 - SQL Server Starts Automatically on VM Boot (Priority: P1)
 
-Each VM is created fresh and destroyed regularly. The shared write service must be
-running before any agent session starts, without manual intervention after VM creation.
+Each VM is created fresh and destroyed regularly. The shared write service
+must be running before any agent session starts, without manual intervention
+after VM creation.
 
-After a VM is provisioned once, the shared write service starts automatically on every
-boot — including the initial boot after provisioning — without operator action.
+After a VM is provisioned once, the shared write service starts automatically
+on every boot — including the initial boot after provisioning — without
+operator action.
 
 **Why this priority**: Auto-startup is the foundational prerequisite. Without it,
 the shared service is absent when agents start, and no other story can deliver value.
 
-**Independent Test**: Provision a VM, reboot it, start an agent session. Verify the
-agent connects to the shared service without any manual steps.
+**Independent Test**: Provision a VM, reboot it, start an agent session.
+Verify the agent connects to the shared service without any manual steps.
 
 **Acceptance Scenarios**:
 
-1. **Given** a VM provisioned for the first time, **When** the VM completes its boot
-   sequence, **Then** the shared write service is running and accepting connections
-   before any agent session can begin.
+1. **Given** a VM provisioned for the first time, **When** the VM
+   completes its boot sequence, **Then** the shared write service is
+   running and accepting connections before any agent session can begin.
 2. **Given** a running shared write service, **When** the service process is
    killed (SIGKILL), **Then** the service restarts automatically within a few
    seconds without any operator action (FR-003).
@@ -46,36 +48,39 @@ agent connects to the shared service without any manual steps.
 
 ---
 
-### User Story 2 - Developer Initializes Repository with Dolt Backend (Priority: P2)
+### User Story 2 - Developer Initializes Repository with Dolt Backend (P2)
 
-A developer who wants to use the running Dolt SQL server for task tracking in their git
-repository runs `bd init --server` once in that repository. After initialization, tasks
-created in the repository are stored in the Dolt server. This is an explicit
-per-repository opt-in; only developers who choose server-backed task tracking need this
-step.
+A developer who wants to use the running Dolt SQL server for task tracking
+in their git repository runs `bd init --server` once in that repository.
+After initialization, tasks created in the repository are stored in the
+Dolt server. This is an explicit per-repository opt-in; only developers
+who choose server-backed task tracking need this step.
 
-**Why this priority**: Without this step no repository connects to the server. This is
-the opt-in that activates the feature for actual use in a project.
+**Why this priority**: Without this step no repository connects to the
+server. This is the opt-in that activates the feature for actual use in
+a project.
 
 **Independent Test**:
 
 1. Create a new directory, run `git init`, add a file and commit.
 2. Run `bd init --server`.
 3. Create a task with `bd create`.
-4. Query the Dolt server directly to verify the task record exists in the Dolt database
-   for the repository's prefix — proving storage landed in Dolt, not an embedded fallback.
+4. Query the Dolt server directly to verify the task record exists in the
+   Dolt database for the repository's prefix — proving storage landed in
+   Dolt, not an embedded fallback.
 
 **Acceptance Scenarios**:
 
-1. **Given** a git repository with at least one commit and the Dolt server running,
-   **When** `bd init --server` is run, **Then** beads initializes successfully with the
-   Dolt server as its backend.
-2. **Given** a repository initialized with `bd init --server`, **When** a task is
-   created via `bd create`, **Then** querying the Dolt server directly shows the task
-   present in the Dolt database for that repository's prefix.
-3. **Given** a repository initialized with `bd init --server`, **When** the Dolt server
-   is queried, **Then** a dedicated database exists for the repository's prefix,
-   confirming server-backed storage is active.
+1. **Given** a git repository with at least one commit and the Dolt server
+   running, **When** `bd init --server` is run, **Then** beads initializes
+   successfully with the Dolt server as its backend.
+2. **Given** a repository initialized with `bd init --server`, **When** a
+   task is created via `bd create`, **Then** querying the Dolt server
+   directly shows the task present in the Dolt database for that
+   repository's prefix.
+3. **Given** a repository initialized with `bd init --server`, **When**
+   the Dolt server is queried, **Then** a dedicated database exists for
+   the repository's prefix, confirming server-backed storage is active.
 
 ---
 
@@ -83,17 +88,18 @@ the opt-in that activates the feature for actual use in a project.
 
 - What if provisioning is re-run on a VM where the service is already running? The
   re-run must complete without disrupting or duplicating the running service.
-- What if `bd init --server` (new repo configuration) or `bd bootstrap` (restoring
-  tasks in a repo already configured with server backend) is run when the server is
-  not running? Both commands must fail with a clear, actionable error. Silent fallback
-  to embedded mode is not acceptable in either case.
+- What if `bd init --server` (new repo configuration) or `bd bootstrap`
+  (restoring tasks in a repo already configured with server backend) is
+  run when the server is not running? Both commands must fail with a
+  clear, actionable error. Silent fallback to embedded mode is not
+  acceptable in either case.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: The VM provisioning process MUST install the Dolt database binary on
-  each new VM as part of standard base setup.
+- **FR-001**: The VM provisioning process MUST install the Dolt database
+  binary on each new VM as part of standard base setup.
 - **FR-002**: The shared write service MUST start automatically when the VM boots,
   with no operator action required after provisioning.
 - **FR-003**: The shared write service MUST restart automatically if it stops

--- a/specs/008-dolt-sql-server-role/tasks.md
+++ b/specs/008-dolt-sql-server-role/tasks.md
@@ -26,7 +26,7 @@ script. `molecule/default/molecule.yml` and
 `molecule/default/prepare.yml` are generated here and MUST NOT be
 edited afterwards (canonical per molecule-testing skill).
 
-- [ ] T001 Scaffold role: run `bash scripts/new-role.sh dolt_sql_server`
+- [x] T001 Scaffold role: run `bash scripts/new-role.sh dolt_sql_server`
   to create `roles/dolt_sql_server/` skeleton including canonical
   `molecule/default/molecule.yml` and `molecule/default/prepare.yml`
   — do NOT edit these two files afterwards
@@ -42,7 +42,7 @@ before Phase 3.
 **⚠️ CRITICAL**: No US1 or US2 work can begin until this phase is
 complete.
 
-- [ ] T002 Create `roles/dolt_sql_server/defaults/main.yml` with
+- [x] T002 Create `roles/dolt_sql_server/defaults/main.yml` with
   ten variables: `dolt_version: "v2.0.8"`,
   `dolt_install_path: /usr/local/bin/dolt`,
   `dolt_listen_host: 127.0.0.1`, `dolt_listen_port: 3306`,
@@ -50,7 +50,7 @@ complete.
   `dolt_config_path: "{{ dolt_config_dir }}/config.yaml"`,
   `dolt_service_user: dolt`, `dolt_service_name: dolt-sql-server`,
   `dolt_readiness_timeout: 30`
-- [ ] T003 Create `roles/dolt_sql_server/meta/main.yml` with
+- [x] T003 Create `roles/dolt_sql_server/meta/main.yml` with
   `galaxy_info` (namespace: wonderbird, role_name: dolt_sql_server)
   and platforms: Ubuntu 22.04 (jammy) and 24.04 (noble)
 
@@ -71,21 +71,21 @@ zero changes.
 
 ### Implementation for User Story 1
 
-- [ ] T004 [P] [US1] Create config template at
+- [x] T004 [P] [US1] Create config template at
   `roles/dolt_sql_server/templates/config.yaml.j2` rendering
   `listener.host`, `listener.port`, and `data_dir` from role
   variables (contract: server-config.md)
-- [ ] T005 [P] [US1] Create systemd unit template at
+- [x] T005 [P] [US1] Create systemd unit template at
   `roles/dolt_sql_server/templates/dolt-sql-server.service.j2`
   with `Type=simple`, `User={{ dolt_service_user }}`,
   `ExecStart` launching `dolt sql-server --config={{ dolt_config_path }}`,
   `Restart=always`, `RestartSec=2`,
   `WantedBy=multi-user.target` (contract: systemd-service.md)
-- [ ] T006 [US1] Create `roles/dolt_sql_server/handlers/main.yml`
+- [x] T006 [US1] Create `roles/dolt_sql_server/handlers/main.yml`
   with handler `Restart dolt-sql-server` running
   `ansible.builtin.systemd_service` with `daemon_reload: true`,
   `name: "{{ dolt_service_name }}"`, `state: restarted`
-- [ ] T007 [US1] Implement `roles/dolt_sql_server/tasks/main.yml`
+- [x] T007 [US1] Implement `roles/dolt_sql_server/tasks/main.yml`
   with the full task sequence:
   (1) `assert` `dolt_version` non-empty, `dolt_listen_host`
   is loopback, and `dolt_listen_port` is an integer in `1–65535`;
@@ -106,10 +106,10 @@ zero changes.
   (8) `wait_for` host `{{ dolt_listen_host }}` port
   `{{ dolt_listen_port }}` timeout `{{ dolt_readiness_timeout }}`,
   then `assert` port listening with message naming host:port
-- [ ] T008 [P] [US1] Create converge.yml at
+- [x] T008 [P] [US1] Create converge.yml at
   `roles/dolt_sql_server/molecule/default/converge.yml`
   applying the `dolt_sql_server` role with `become: true`
-- [ ] T009 [US1] Create verify.yml at
+- [x] T009 [US1] Create verify.yml at
   `roles/dolt_sql_server/molecule/default/verify.yml` asserting:
   (1) `dolt --version` output matches `dolt_version` with leading
   `v` stripped (`regex_replace('^v', '')`);
@@ -120,24 +120,24 @@ zero changes.
   in background, `wait_for` port 3306, run `SELECT 1` via
   `mysql` client (assert exit 0), run `ss -tlnp`, assert
   output contains `127.0.0.1:3306` and NOT `0.0.0.0:3306`
-- [ ] T010 [US1] Add `- role: dolt_sql_server` to the mandatory
+- [x] T010 [US1] Add `- role: dolt_sql_server` to the mandatory
   `roles:` block in `configure-linux-roles.yml` after `tmux`
   (no tag needed — containerisable parts work without systemd)
-- [ ] T011 [P] [US1] Extend query-versions.yml:
+- [x] T011 [P] [US1] Extend query-versions.yml:
   `playbooks/update-versions/query-versions.yml` — slurp
   `roles/dolt_sql_server/defaults/main.yml`, extract
   `current_dolt_version`, include `tasks/fetch-github-release.yml`
   with `github_repo: dolthub/dolt`, save `fetched_dolt_tag`,
   add report line, extend fail-if-stale condition (reuses
   `fetch-github-release.yml` — no new fetch logic per DRY)
-- [ ] T012 [P] [US1] Extend perform-updates.yml:
+- [x] T012 [P] [US1] Extend perform-updates.yml:
   `playbooks/update-versions/perform-updates.yml` — include
   `tasks/fetch-github-release.yml` with
   `github_repo: dolthub/dolt`, then `ansible.builtin.replace`
   the `dolt_version` line in
   `roles/dolt_sql_server/defaults/main.yml` (reuses existing
   pattern per D8)
-- [ ] T013 [P] [US1] Add Dolt row to
+- [x] T013 [P] [US1] Add Dolt row to
   `docs/architecture/version-update-playbooks.md` tracked-tools
   table: Role `dolt_sql_server`, version_key `dolt_version`,
   checksum_key `—`, source `GitHub Releases API dolthub/dolt`
@@ -162,7 +162,7 @@ DB present in Dolt (not an embedded fallback).
 
 ### Implementation for User Story 2
 
-- [ ] T014 [US2] Create `roles/dolt_sql_server/README.md`
+- [x] T014 [US2] Create `roles/dolt_sql_server/README.md`
   documenting: role purpose and boundary (install + service only;
   no DB init/restore/backup per FR-006); all `defaults/main.yml`
   variables with types and defaults; postconditions on success
@@ -179,10 +179,10 @@ role boundary is clear.
 
 ## Phase 5: Polish and Cross-Cutting Concerns
 
-- [ ] T015 [P] Run `format-markdown` skill over all changed
+- [x] T015 [P] Run `format-markdown` skill over all changed
   Markdown files: `roles/dolt_sql_server/README.md`,
   `docs/architecture/version-update-playbooks.md`, spec docs
-- [ ] T016 Run `molecule test` from `roles/dolt_sql_server/` and
+- [x] T016 Run `molecule test` from `roles/dolt_sql_server/` and
   confirm zero test failures and idempotence step `changed=0`
 
 ---

--- a/specs/008-dolt-sql-server-role/tasks.md
+++ b/specs/008-dolt-sql-server-role/tasks.md
@@ -1,0 +1,262 @@
+# Tasks: Dolt SQL Server Ansible Role
+
+**Input**: Design documents from `/specs/008-dolt-sql-server-role/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md,
+contracts/, quickstart.md
+
+**Tests**: No separate test tasks — Molecule verify.yml assertions
+are part of the role implementation (not TDD pre-write; spec does
+not request it).
+
+**Organization**: Tasks grouped by user story for independent
+implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Parallelizable (different files, no shared dependencies)
+- **[Story]**: US1 = SQL Server Starts Automatically on VM Boot (P1);
+  US2 = Developer Initializes Repository with Dolt Backend (P2)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Scaffold the role skeleton using the canonical helper
+script. `molecule/default/molecule.yml` and
+`molecule/default/prepare.yml` are generated here and MUST NOT be
+edited afterwards (canonical per molecule-testing skill).
+
+- [ ] T001 Scaffold role: run `bash scripts/new-role.sh dolt_sql_server`
+  to create `roles/dolt_sql_server/` skeleton including canonical
+  `molecule/default/molecule.yml` and `molecule/default/prepare.yml`
+  — do NOT edit these two files afterwards
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish all role variables and metadata before any
+template, task, or Molecule file can reference them. MUST complete
+before Phase 3.
+
+**⚠️ CRITICAL**: No US1 or US2 work can begin until this phase is
+complete.
+
+- [ ] T002 Create `roles/dolt_sql_server/defaults/main.yml` with
+  ten variables: `dolt_version: "v2.0.8"`,
+  `dolt_install_path: /usr/local/bin/dolt`,
+  `dolt_listen_host: 127.0.0.1`, `dolt_listen_port: 3306`,
+  `dolt_data_dir: /var/lib/dolt`, `dolt_config_dir: /etc/dolt`,
+  `dolt_config_path: "{{ dolt_config_dir }}/config.yaml"`,
+  `dolt_service_user: dolt`, `dolt_service_name: dolt-sql-server`,
+  `dolt_readiness_timeout: 30`
+- [ ] T003 Create `roles/dolt_sql_server/meta/main.yml` with
+  `galaxy_info` (namespace: wonderbird, role_name: dolt_sql_server)
+  and platforms: Ubuntu 22.04 (jammy) and 24.04 (noble)
+
+**Checkpoint**: Defaults and metadata in place — Phase 3 can begin.
+
+---
+
+## Phase 3: User Story 1 — SQL Server Starts Automatically (P1)
+
+**Goal**: Dolt binary installed, loopback-only config rendered,
+systemd unit deployed and enabled; server starts on every boot;
+idempotent re-provisioning does not disrupt running service;
+version pin registered with update-version playbooks.
+
+**Independent Test**: `cd roles/dolt_sql_server && molecule test`
+— all assertions in verify.yml pass; idempotence step reports
+zero changes.
+
+### Implementation for User Story 1
+
+- [ ] T004 [P] [US1] Create config template at
+  `roles/dolt_sql_server/templates/config.yaml.j2` rendering
+  `listener.host`, `listener.port`, and `data_dir` from role
+  variables (contract: server-config.md)
+- [ ] T005 [P] [US1] Create systemd unit template at
+  `roles/dolt_sql_server/templates/dolt-sql-server.service.j2`
+  with `Type=simple`, `User={{ dolt_service_user }}`,
+  `ExecStart` launching `dolt sql-server --config={{ dolt_config_path }}`,
+  `Restart=always`, `RestartSec=2`,
+  `WantedBy=multi-user.target` (contract: systemd-service.md)
+- [ ] T006 [US1] Create `roles/dolt_sql_server/handlers/main.yml`
+  with handler `Restart dolt-sql-server` running
+  `ansible.builtin.systemd_service` with `daemon_reload: true`,
+  `name: "{{ dolt_service_name }}"`, `state: restarted`
+- [ ] T007 [US1] Implement `roles/dolt_sql_server/tasks/main.yml`
+  with the full task sequence:
+  (1) `assert` `dolt_version` non-empty, `dolt_listen_host`
+  is loopback, and `dolt_listen_port` is an integer in `1–65535`;
+  (2) create `dolt` system user (`system: true`, no login shell);
+  (3) create `dolt_data_dir` and `dolt_config_dir` owned by
+  service user;
+  (4) `get_url` arch-specific tarball (`x86_64`→amd64,
+  `aarch64`→arm64) guarded by `stat`+version check, then
+  `unarchive` and place binary at `dolt_install_path` mode 0755;
+  (5) `template` `config.yaml.j2` → `dolt_config_path`, notify
+  restart handler;
+  (6) `template` service unit →
+  `/etc/systemd/system/{{ dolt_service_name }}.service`, notify
+  restart handler;
+  (7) `systemd_service` `daemon_reload`, `enabled: true`,
+  `state: started`, guarded on
+  `ansible_facts['service_mgr'] == 'systemd'`;
+  (8) `wait_for` host `{{ dolt_listen_host }}` port
+  `{{ dolt_listen_port }}` timeout `{{ dolt_readiness_timeout }}`,
+  then `assert` port listening with message naming host:port
+- [ ] T008 [P] [US1] Create converge.yml at
+  `roles/dolt_sql_server/molecule/default/converge.yml`
+  applying the `dolt_sql_server` role with `become: true`
+- [ ] T009 [US1] Create verify.yml at
+  `roles/dolt_sql_server/molecule/default/verify.yml` asserting:
+  (1) `dolt --version` output matches `dolt_version` with leading
+  `v` stripped (`regex_replace('^v', '')`);
+  (2) `/etc/dolt/config.yaml` contains `host: 127.0.0.1`;
+  (3) `/etc/systemd/system/dolt-sql-server.service` exists and
+  contains `Restart=always` and `WantedBy=multi-user.target`;
+  (4) functional smoke test — start `dolt sql-server --config`
+  in background, `wait_for` port 3306, run `SELECT 1` via
+  `mysql` client (assert exit 0), run `ss -tlnp`, assert
+  output contains `127.0.0.1:3306` and NOT `0.0.0.0:3306`
+- [ ] T010 [US1] Add `- role: dolt_sql_server` to the mandatory
+  `roles:` block in `configure-linux-roles.yml` after `tmux`
+  (no tag needed — containerisable parts work without systemd)
+- [ ] T011 [P] [US1] Extend query-versions.yml:
+  `playbooks/update-versions/query-versions.yml` — slurp
+  `roles/dolt_sql_server/defaults/main.yml`, extract
+  `current_dolt_version`, include `tasks/fetch-github-release.yml`
+  with `github_repo: dolthub/dolt`, save `fetched_dolt_tag`,
+  add report line, extend fail-if-stale condition (reuses
+  `fetch-github-release.yml` — no new fetch logic per DRY)
+- [ ] T012 [P] [US1] Extend perform-updates.yml:
+  `playbooks/update-versions/perform-updates.yml` — include
+  `tasks/fetch-github-release.yml` with
+  `github_repo: dolthub/dolt`, then `ansible.builtin.replace`
+  the `dolt_version` line in
+  `roles/dolt_sql_server/defaults/main.yml` (reuses existing
+  pattern per D8)
+- [ ] T013 [P] [US1] Add Dolt row to
+  `docs/architecture/version-update-playbooks.md` tracked-tools
+  table: Role `dolt_sql_server`, version_key `dolt_version`,
+  checksum_key `—`, source `GitHub Releases API dolthub/dolt`
+
+**Checkpoint**: `molecule test` passes all assertions; idempotence
+reports zero changes. Version-update playbooks gain Dolt support.
+Role wired into provisioning.
+
+---
+
+## Phase 4: User Story 2 — Developer Repository Opt-In (P2)
+
+**Goal**: Role guarantees server accepts `bd init --server` with no
+additional server-side configuration (FR-004, SC-004). No new role
+code needed — US2 is a developer opt-in enabled by US1's server
+running on `127.0.0.1:3306` with no-password root access.
+
+**Independent Test**: Follow quickstart.md § "Developer opt-in"
+procedure — `bd init --server`, `bd create`, then
+`dolt sql-client --execute "SHOW DATABASES;"` confirms repo-prefix
+DB present in Dolt (not an embedded fallback).
+
+### Implementation for User Story 2
+
+- [ ] T014 [US2] Create `roles/dolt_sql_server/README.md`
+  documenting: role purpose and boundary (install + service only;
+  no DB init/restore/backup per FR-006); all `defaults/main.yml`
+  variables with types and defaults; postconditions on success
+  (binary at pinned version, service enabled + active,
+  loopback-only listener, no-password root accessible);
+  developer opt-in procedure (`bd init --server`, verify with
+  `dolt sql-client SHOW DATABASES`); link to `quickstart.md`
+  for validation steps; explicit non-goals section
+
+**Checkpoint**: README documents the US2 developer opt-in path;
+role boundary is clear.
+
+---
+
+## Phase 5: Polish and Cross-Cutting Concerns
+
+- [ ] T015 [P] Run `format-markdown` skill over all changed
+  Markdown files: `roles/dolt_sql_server/README.md`,
+  `docs/architecture/version-update-playbooks.md`, spec docs
+- [ ] T016 Run `molecule test` from `roles/dolt_sql_server/` and
+  confirm zero test failures and idempotence step `changed=0`
+
+---
+
+## Dependencies and Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 scaffold — BLOCKS
+  all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 (variable names used in all
+  templates and tasks)
+  - T004, T005, T008 can start in parallel once T002/T003 are done
+  - T006 after T004/T005 are conceptualized
+  - T007 after T004, T005, T006
+  - T009 after T007
+  - T010, T011, T012, T013 can start in parallel after T002/T003
+- **US2 (Phase 4)**: Depends on Phase 3 — server must exist before
+  README documents it
+- **Polish (Phase 5)**: Depends on all Markdown files being
+  finalized
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Foundational — no dependencies on US2
+- **US2 (P2)**: Depends on US1 completion (server must be implemented
+  before README documents the developer opt-in); no new role code
+  required
+
+### Within Phase 3
+
+- T004, T005: parallel (different template files)
+- T006: parallel with T004/T005; logically before T007
+- T007: after T004, T005, T006 (references all three)
+- T008: parallel with T007 (converge just applies role; trivial)
+- T009: after T007 (verify assertions derived from task output)
+- T010: independent of T007 (different file)
+- T011, T012, T013: parallel with each other and with
+  T008/T009/T010 (all different files)
+
+---
+
+## Parallel Examples
+
+```bash
+# Parallel group A (templates + handler):
+Task T004 — Create templates/config.yaml.j2
+Task T005 — Create templates/dolt-sql-server.service.j2
+
+# Parallel group B (version-update integration):
+Task T011 — query-versions.yml Dolt entry
+Task T012 — perform-updates.yml Dolt entry
+Task T013 — version-update-playbooks.md row
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (User Story 1 Only)
+
+1. Complete Phase 1: Scaffold
+2. Complete Phase 2: Defaults + meta (CRITICAL — blocks all work)
+3. Complete Phase 3: Full role + Molecule + provisioning wire-up +
+   version tracking
+4. **STOP and VALIDATE**: `molecule test` passes; idempotence clean;
+   version playbooks detect/apply Dolt updates
+5. US1 is independently deployable — server runs on provisioned VMs
+
+### Incremental Delivery
+
+1. Phase 1 + Phase 2 → skeleton with variables
+2. Phase 3 → complete US1 + Molecule validation + version tracking
+   → deploy
+3. Phase 4 → README with US2 developer opt-in → document
+4. Phase 5 → Markdown lint + final Molecule gate → merge-ready


### PR DESCRIPTION
## Summary

- Adds `roles/dolt_sql_server` Ansible role: installs Dolt binary, configures and enables `dolt sql-server` as a systemd service on each new VM boot
- SQL server binds to loopback only (`127.0.0.1:3306`) — no external exposure
- Includes Molecule test scenario (create → prepare → converge → idempotence → verify → destroy)
- Tarball checksum verification via `dolt_sha256_amd64` / `dolt_sha256_arm64` in role defaults

## Motivation

Agent VMs are ephemeral. By default beads uses an embedded Dolt backend that permits only one concurrent writer. When multiple AI agents run in parallel, all but one lose write access, causing lost task tracking and agent focus drift. This role provisions a local Dolt SQL server so all parallel agent sessions connect to the shared server, eliminating write-lock contention.

## Role boundary

- Install + systemd service only
- Database init (`dolt init`) → `bd bootstrap`
- Data restore → `bd dolt pull` / `bd bootstrap`
- Data backup → `bd dolt push`

## Test plan

- [ ] `molecule test` from `roles/dolt_sql_server/` passes
- [ ] Idempotence step reports no changes on second converge
- [ ] Verify step confirms dolt binary version, loopback-only binding, systemd unit, and SQL connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)