### PR TITLE
fix: dolt-sql-server failed to start due to missing HOME directory

### DIFF
--- a/roles/dolt_sql_server/templates/dolt-sql-server.service.j2
+++ b/roles/dolt_sql_server/templates/dolt-sql-server.service.j2
@@ -5,6 +5,8 @@ After=network.target
 [Service]
 Type=simple
 User={{ dolt_service_user }}
+Environment=HOME={{ dolt_data_dir }}
+WorkingDirectory={{ dolt_data_dir }}
 ExecStart={{ dolt_install_path }} sql-server --config={{ dolt_config_path }}
 Restart=always
 RestartSec=2


### PR DESCRIPTION
## Summary

- Dolt reads `$HOME` at startup to locate `~/.dolt/` configuration
- Service user `dolt` is created with `create_home: false` → `/home/dolt` does not exist → service exits immediately with status 1
- Fix: add `Environment=HOME={{ dolt_data_dir }}` and `WorkingDirectory={{ dolt_data_dir }}` to the systemd unit template so dolt resolves HOME to `/var/lib/dolt` (exists, owned by dolt user)

## Test plan

- [x] Molecule `test` scenario passes (create → prepare → converge → idempotence → verify → destroy)
- [ ] Deployer re-runs playbook against lorien and confirms `dolt-sql-server` starts and listens on `127.0.0.1:3306`

🤖 Generated with [Claude Code](https://claude.ai/code)