### PR TITLE
feat(claude_code): install specify-cli and context7 plugin

### DIFF
--- a/roles/claude_code/molecule/default/Dockerfile
+++ b/roles/claude_code/molecule/default/Dockerfile
@@ -1,0 +1,6 @@
+FROM docker.io/library/ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends \
+       python3 sudo git curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/roles/claude_code/molecule/default/Dockerfile
+++ b/roles/claude_code/molecule/default/Dockerfile
@@ -2,5 +2,5 @@ FROM docker.io/library/ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq \
     && apt-get install -y -qq --no-install-recommends \
-       python3 sudo git curl ca-certificates \
+       python3 sudo git curl ca-certificates pipx \
     && rm -rf /var/lib/apt/lists/*

--- a/roles/claude_code/molecule/default/molecule.yml
+++ b/roles/claude_code/molecule/default/molecule.yml
@@ -6,12 +6,14 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: docker.io/library/ubuntu:24.04
-    pre_build_image: true
+    image: molecule_claude_code_instance
+    pre_build_image: false
+    dockerfile: Dockerfile
 provisioner:
   name: ansible
   env:
     ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
+    ANSIBLE_PODMAN_MOUNT_DETECTION: "false"
 verifier:
   name: ansible
 scenario:

--- a/roles/claude_code/molecule/default/prepare.yml
+++ b/roles/claude_code/molecule/default/prepare.yml
@@ -5,24 +5,6 @@
   gather_facts: false
   become: true
   tasks:
-    - name: Update apt cache
-      ansible.builtin.raw: apt-get update
-      # become: false — sudo is not yet installed; run directly as root
-      become: false
-      changed_when: true
-
-    - name: Install python3 and sudo
-      ansible.builtin.raw: apt-get install -y -qq python3 sudo
-      # become: false — sudo is not yet installed; run directly as root
-      become: false
-      changed_when: true
-
-    - name: Install git and curl
-      ansible.builtin.raw: apt-get install -y -qq git curl
-      # become: false — sudo is not yet installed; run directly as root
-      become: false
-      changed_when: true
-
     - name: Create testuser
       ansible.builtin.user:
         name: testuser
@@ -44,11 +26,15 @@
         creates: /home/testuser/.nvm/nvm.sh
       become: true
       become_user: testuser
+      environment:
+        HOME: /home/testuser
 
     - name: Install Node.js LTS via nvm
-      ansible.builtin.shell: source ~/.nvm/nvm.sh && nvm install --lts
+      ansible.builtin.shell: source /home/testuser/.nvm/nvm.sh && nvm install --lts
       args:
         executable: /bin/bash
       become: true
       become_user: testuser
+      environment:
+        HOME: /home/testuser
       changed_when: false

--- a/roles/claude_code/molecule/default/verify.yml
+++ b/roles/claude_code/molecule/default/verify.yml
@@ -200,3 +200,19 @@
           - "'context7' in mcp_list_result.stdout"
         fail_msg: "context7 not found in 'claude mcp list' output"
         success_msg: "context7 MCP server is registered"
+
+    - name: Run specify --version as testuser
+      ansible.builtin.command: specify --version
+      become: true
+      become_user: testuser
+      environment:
+        PATH: "/home/testuser/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      register: specify_version_result
+      changed_when: false
+
+    - name: Assert specify --version succeeds
+      ansible.builtin.assert:
+        that:
+          - specify_version_result.rc == 0
+        fail_msg: "specify --version failed with rc {{ specify_version_result.rc }}"
+        success_msg: "specify-cli available: {{ specify_version_result.stdout }}"

--- a/roles/claude_code/molecule/default/verify.yml
+++ b/roles/claude_code/molecule/default/verify.yml
@@ -174,3 +174,29 @@
           - rtk_init_result.rc == 0
         fail_msg: "rtk init -g failed with rc {{ rtk_init_result.rc }}"
         success_msg: "rtk init -g succeeded for testuser"
+
+    - name: Check context7 plugin cache directory exists
+      ansible.builtin.stat:
+        path: /home/testuser/.claude/plugins/cache/claude-plugins-official/context7
+      register: context7_cache_stat
+
+    - name: Assert context7 plugin cache directory is present
+      ansible.builtin.assert:
+        that:
+          - context7_cache_stat.stat.exists
+        fail_msg: "context7 plugin cache not found at /home/testuser/.claude/plugins/cache/claude-plugins-official/context7"
+        success_msg: "context7 plugin cache found at /home/testuser/.claude/plugins/cache/claude-plugins-official/context7"
+
+    - name: Check context7 MCP server is registered
+      ansible.builtin.shell: /home/testuser/.local/bin/claude mcp list
+      become: true
+      become_user: testuser
+      changed_when: false
+      register: mcp_list_result
+
+    - name: Assert context7 MCP server is auto-registered
+      ansible.builtin.assert:
+        that:
+          - "'context7' in mcp_list_result.stdout"
+        fail_msg: "context7 not found in 'claude mcp list' output"
+        success_msg: "context7 MCP server is registered"

--- a/roles/claude_code/tasks/install-addons.yml
+++ b/roles/claude_code/tasks/install-addons.yml
@@ -141,3 +141,35 @@
     PATH: "/home/{{ item }}/.local/bin:{{ ansible_env.PATH }}"
   loop: "{{ desktop_user_names }}"
   when: "'  ❯ caveman@caveman' not in (plugin_list_check.results | selectattr('item', 'equalto', item) | first).stdout_lines"
+
+- name: Add claude-plugins-official marketplace to Claude Code
+  ansible.builtin.shell:
+    cmd: /home/{{ item }}/.local/bin/claude plugin marketplace add anthropics/claude-plugins-official
+  become: true
+  become_user: "{{ item }}"
+  environment:
+    PATH: "/home/{{ item }}/.local/bin:{{ ansible_env.PATH }}"
+  loop: "{{ desktop_user_names }}"
+  when: >-
+    (plugin_marketplace_check.results
+     | selectattr('item', 'equalto', item)
+     | first).stdout_lines
+     | select('match', '^\\s*❯\\s+claude-plugins-official$')
+     | list
+     | length == 0
+
+- name: Install context7 plugin
+  ansible.builtin.shell:
+    cmd: /home/{{ item }}/.local/bin/claude plugin install context7@claude-plugins-official
+  become: true
+  become_user: "{{ item }}"
+  environment:
+    PATH: "/home/{{ item }}/.local/bin:{{ ansible_env.PATH }}"
+  loop: "{{ desktop_user_names }}"
+  when: >-
+    (plugin_list_check.results
+     | selectattr('item', 'equalto', item)
+     | first).stdout_lines
+     | select('search', 'context7')
+     | list
+     | length == 0

--- a/roles/claude_code/tasks/install-addons.yml
+++ b/roles/claude_code/tasks/install-addons.yml
@@ -173,3 +173,17 @@
      | select('search', 'context7')
      | list
      | length == 0
+
+# -----
+# Install speckit CLI for each desktop user
+# -----
+
+- name: Install specify-cli via pipx
+  ansible.builtin.shell:
+    cmd: pipx install git+https://github.com/github/spec-kit.git@v0.8.18
+    creates: /home/{{ item }}/.local/bin/specify
+  become: true
+  become_user: "{{ item }}"
+  environment:
+    PATH: "/home/{{ item }}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  loop: "{{ desktop_user_names }}"


### PR DESCRIPTION
## Summary

- Install `specify-cli` via `pipx` for each desktop user, pinned to `git+https://github.com/github/spec-kit.git@v0.8.18`
- Add `anthropics/claude-plugins-official` marketplace and install `context7@claude-plugins-official` for each desktop user using the probe+when idempotency pattern
- Fix molecule test infrastructure: switch to Dockerfile-based image to avoid rootless podman killing containers during the Ansible pre-Python bootstrap copy phase (`podman cp --pause=false`)

## Test plan

- [ ] `molecule test` passes in `roles/claude_code/` (create → prepare → converge → idempotence → verify → destroy)
- [ ] `specify --version` succeeds for desktop users
- [ ] `claude mcp list` contains `context7` for desktop users
- [ ] Idempotence check passes (no changed tasks on second run)

🤖 Generated with [Claude Code](https://claude.ai/code)