### PR TITLE
feat(claude_code): configure Exa MCP server for desktop users

### DIFF
--- a/roles/claude_code/README.md
+++ b/roles/claude_code/README.md
@@ -1,10 +1,11 @@
-#SPDX-License-Identifier: MIT-0
+<!-- SPDX-License-Identifier: MIT-0 -->
 # claude_code
 
 Ansible role that installs [Anthropic's Claude Code](https://claude.ai/code) CLI
-on Linux for each desktop user, verifies binary integrity, and installs the
+on Linux for each desktop user, verifies binary integrity, installs the
 [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) and
-[caveman](https://github.com/JuliusBrussee/caveman) Claude Code plugins.
+[caveman](https://github.com/JuliusBrussee/caveman) Claude Code plugins, and
+configures the [Exa](https://exa.ai) MCP server for web search.
 
 ## Requirements
 
@@ -16,10 +17,11 @@ on Linux for each desktop user, verifies binary integrity, and installs the
 ## Role Variables
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `claude_code_manifest_base_url` | Google Storage URL | Base URL for the Claude Code release manifest |
 | `claude_code_platform_map` | `{x86_64: linux-x64, aarch64: linux-arm64}` | Maps `ansible_architecture` to Claude Code platform string |
 | `desktop_user_names` | *(required)* | List of local usernames to install Claude Code for |
+| `desktop_users` | *(required)* | List of user objects with `name`, `password`, and `exa_api_key` |
 
 ## Dependencies
 
@@ -35,27 +37,38 @@ None. See `meta/main.yml` for details.
         desktop_user_names:
           - alice
           - bob
+        desktop_users:
+          - name: alice
+            password: "{{ vault_alice_password }}"
+            exa_api_key: "{{ vault_alice_exa_api_key }}"
+          - name: bob
+            password: "{{ vault_bob_password }}"
+            exa_api_key: "{{ vault_bob_exa_api_key }}"
 ```
 
 ## What This Role Does
 
 1. Verifies the target architecture is supported
 2. Fetches the latest Claude Code version and release manifest
-3. Downloads and runs the official Claude Code installer for each user (skipped if already installed)
+3. Downloads and runs the official Claude Code installer for each user
+   (skipped if already installed)
 4. Verifies the installed binary checksum against the release manifest
 5. Adds `~/.local/bin` to each user's `PATH` via `.bashrc`
 6. Clones the oh-my-claudecode source repo to `~/Documents/Cline/oh-my-claudecode`
 7. Installs the [beads](https://github.com/steveyegge/beads) issue tracker (`bd`)
 8. Registers and installs the oh-my-claudecode Claude Code plugin
 9. Registers and installs the caveman Claude Code plugin
+10. Configures the [Exa](https://exa.ai) MCP server (`exa`) with the user's API
+    key (skipped if already registered)
 
 ## Post-install Manual Steps
 
 After running the playbook, each user must complete initial setup interactively:
 
 1. Run `claude` to open a Claude Code session
-2. Run `/setup` inside the session. If the [Exa](https://exa.ai) and GitHub MCPs
-   are desired, then corresponding API keys (PATs) are required.
+2. Run `/setup` inside the session. The Exa MCP server is configured
+   automatically by this role. If the GitHub MCP is desired, a GitHub personal
+   access token is required.
 3. Run `/caveman` to activate caveman mode
 
 ## License

--- a/roles/claude_code/molecule/default/converge.yml
+++ b/roles/claude_code/molecule/default/converge.yml
@@ -6,5 +6,9 @@
   vars:
     desktop_user_names:
       - testuser
+    desktop_users:
+      - name: testuser
+        password: testpassword
+        exa_api_key: test_fake_exa_key
   roles:
     - role: claude_code

--- a/roles/claude_code/molecule/default/verify.yml
+++ b/roles/claude_code/molecule/default/verify.yml
@@ -216,3 +216,17 @@
           - specify_version_result.rc == 0
         fail_msg: "specify --version failed with rc {{ specify_version_result.rc }}"
         success_msg: "specify-cli available: {{ specify_version_result.stdout }}"
+
+    - name: Check exa MCP server is configured
+      ansible.builtin.shell: /home/testuser/.local/bin/claude mcp list
+      become: true
+      become_user: testuser
+      changed_when: false
+      register: exa_mcp_list_result
+
+    - name: Assert exa MCP server is registered
+      ansible.builtin.assert:
+        that:
+          - "'exa' in exa_mcp_list_result.stdout"
+        fail_msg: "exa MCP server not found in 'claude mcp list' output"
+        success_msg: "exa MCP server is configured"

--- a/roles/claude_code/tasks/install-addons.yml
+++ b/roles/claude_code/tasks/install-addons.yml
@@ -187,3 +187,34 @@
   environment:
     PATH: "/home/{{ item }}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   loop: "{{ desktop_user_names }}"
+
+# -----
+# Configure Exa MCP server for each desktop user
+# -----
+
+- name: Check if exa MCP server is already configured
+  ansible.builtin.shell:
+    cmd: /home/{{ item.name }}/.local/bin/claude mcp list
+  become: true
+  become_user: "{{ item.name }}"
+  environment:
+    PATH: "/home/{{ item.name }}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  loop: "{{ desktop_users }}"
+  failed_when: false
+  changed_when: false
+  register: exa_mcp_check
+
+- name: Configure exa MCP server
+  ansible.builtin.shell:
+    cmd: >
+      /home/{{ item.name }}/.local/bin/claude mcp add --scope user exa
+      -e EXA_API_KEY={{ item.exa_api_key }} -- npx -y exa-mcp-server
+  become: true
+  become_user: "{{ item.name }}"
+  environment:
+    PATH: "/home/{{ item.name }}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  loop: "{{ desktop_users }}"
+  when: >-
+    (exa_mcp_check.results
+     | selectattr('item.name', 'equalto', item.name)
+     | first).stdout is not search('exa')


### PR DESCRIPTION
## Summary

- Add tasks to register the Exa MCP server via `claude mcp add --scope user` for each desktop user, looping over `desktop_users` with an idempotency guard on `claude mcp list`
- Update Molecule converge vars (`exa_api_key: test_fake_exa_key`) and verify assertions to cover the new capability
- Update `README.md` to document new `desktop_users` variable and the Exa MCP configuration step

## Test plan

- [x] `molecule test` passes (full create→prepare→converge→idempotence→verify→destroy lifecycle)
- [x] Verify task asserts `exa` appears in `claude mcp list` output
- [x] Idempotence check passes (0 changed on second converge run)
- [x] `markdownlint` passes on `README.md`

🤖 Generated with [Claude Code](https://claude.ai/code)