### PR TITLE
docs: correct bd dep-add type rules and epic-gating semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,10 +218,16 @@ Built-in types and when to use each:
 
 ### Attaching Issues to Epics (epics cannot be gated)
 
-An epic cannot be excluded from `bd ready` by its children:
+`bd dep add` connects **any pair of issue types except `epic`** — an epic
+connects only to another epic. So an epic cannot be gated out of `bd ready`
+by its non-epic children:
 
-- `bd dep add <epic> <non-epic>` is rejected ("epics can only block other
-  epics"), so a non-epic cannot block its epic.
+- `bd dep add` between an epic and a non-epic is rejected in **both**
+  directions (`<epic> <non-epic>` and `<non-epic> <epic>`), each printing
+  `Error: epics can only block other epics, not tasks` (the message always
+  says "not tasks", whatever the real type). A non-epic therefore cannot block
+  its epic. Epic↔epic edges ARE permitted; non-epic pairs gate normally (a
+  task can block a task, a feature, etc.).
 - `--parent` attaches a child for display/scope only. It does NOT gate
   readiness and does NOT exclude the parent from `bd ready`.
 
@@ -233,16 +239,20 @@ An epic with open children therefore REMAINS in `bd ready`. Do not rely on
 `bd ready` exclusion to track epic scope — read the epic's CHILDREN section
 via `bd show <epic-id>` instead. See
 [triage.md](docs/architecture/concepts/issue-tracking/triage.md) for the
-validated `--parent` / `bd ready` semantics (bd v1.0.4 spike).
+validated dep-add type matrix and `--parent` / `bd ready` semantics
+(bd v1.0.4).
 
 ### Beads Dependency Wiring — Cross-Tree Follow-Ups
 
-When an ADR acceptance, review, or policy decision produces follow-up epics
-that impose compliance requirements on in-flight work in a **different epic
-tree**, add those follow-ups as `bd dep` blockers on the affected issue
-immediately. Tracking a follow-up only under its own parent epic — without
-connecting it to the constrained feature — allows premature closure of work
-that is not yet compliant.
+Operationalizes Principle VIII (cross-tree blocking). When a policy or review
+decision constrains in-flight work in another tree, wire the blocking dep
+**immediately** — but mind the type rule: `bd dep add` cannot make an `epic`
+block a non-epic (rejected; see "Attaching Issues to Epics" above). If the
+follow-up is tracked as an epic, use a **non-epic** issue as the actual
+blocker — a concrete task under that epic, or a `gate` checkpoint (verified:
+a `gate` blocks a non-epic and gates it out of `bd ready`). Wire it as
+`bd dep add <in-flight-issue> <non-epic-blocker>` (in-flight depends on
+blocker).
 
 **Signal the next action for the next session**: after wiring the deps, claim
 both the blocked issue and the immediate actionable follow-up:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,18 +294,12 @@ when no issue is marked `in_progress`.
 
 ## Collaboration with the User
 
-- **Language and style**: Use English throughout. For all user-facing
-  content — chat, code, comments, documentation, beads issues — apply the
-  `caveman full` skill: drop articles, filler, and hedging; fragments OK;
-  short synonyms; technical terms exact. For internal thought processes and
-  inter-LLM communication (subagents, MCP, tool calls) apply the
-  `caveman wenyan-ultra` skill: maximum compression, classical Chinese
-  register. Code blocks, commit messages, and security warnings are always
-  written in normal English regardless of mode.
-- **Language**: chat is in English. For your thinking processes and
-  communication with (sub-)agents use the "caveman wenyan-ultra" skill. For user
-  facing writing (documentation, code, etc.) and chat use "caveman full".
-  Consider all files in `.omc` folder not user facing inter-agent communication.
+- **Language**: English throughout. Apply the caveman skill by audience —
+  `caveman full` for user-facing content (chat, code, comments, documentation,
+  beads issues); `caveman wenyan-ultra` for internal and inter-agent content
+  (thinking, subagents, MCP, tool calls, all files under `.omc/`). Code blocks,
+  commit messages, and security warnings stay in normal English regardless of
+  mode. The skills define each mode.
 - **One question at a time**: when asking the user a question, ask one
   question at a time so they can focus.
 - **Avoid ambiguity**: if instructions are unclear, contradictory, or
@@ -316,20 +310,17 @@ when no issue is marked `in_progress`.
 
 ## Skill index
 
-The table below lists all skills relevant to this project. Local skills are in
-`.claude/skills/`; global skills are installed with the agent runtime. Use it
-to decide which skills to invoke for your current task.
+Skills carrying a constitution-mandated invocation. The agent runtime injects
+the full skill catalog (names + descriptions) each session; only the mandatory
+skill→principle bindings are restated here.
 
-| Skill | Scope | When to invoke |
+| Skill | Invoke when | Principle |
 | --- | --- | --- |
-| [developer](.claude/skills/developer/SKILL.md) | local | Use when expert knowledge of Ansible is required to analyze, implement, or fix features. Project scope: setting up and maintaining virtual machines. |
-| [molecule-testing](.claude/skills/molecule-testing/SKILL.md) | local | Pull in information about the molecule testing setup for Ansible roles. Use when implementing or modifying an Ansible role to set up or maintain its Molecule test scenario. |
-| [review-documentation-here](.claude/skills/review-documentation-here/SKILL.md) | local | Extends review-documentation by project-specific documentation structure, including co-located role documentation. Use when reviewing the project documentation. |
-| [technical-coach](.claude/skills/technical-coach/SKILL.md) | local | Use when expert knowledge of Ansible is required to advise and tutor on automating setup and maintenance of virtual machines. |
-| `commit` | global | Authoritative source for commit format, allowed prefixes, message structure, and co-authorship rules. MUST invoke before creating any commit (Principle V). |
-| `format-markdown` | global | Authoritative Markdown linting ruleset. MUST invoke once at close of task after all Markdown files are finalized (Principle VI). |
-| `fix-problem` | global | Remediation protocol for unexpected obstacles (test failure, tooling error, regression). MUST invoke before attempting fixes (Principle VII). |
-| `review-documentation` | global | Base documentation review strategy and folder structure. Extended by `review-documentation-here` for this project. |
+| `commit` | before creating any commit | V |
+| `format-markdown` | at task close, after all Markdown finalized | VI |
+| `fix-problem` | before fixing any unexpected obstacle | VII |
+| `molecule-testing` | when creating/modifying a role's Molecule scenario | II |
+| `review-documentation-here` | at task close, before `format-markdown` | Documentation Standards |
 
 ## Test environment host architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,8 +347,3 @@ Architecture Decision Records are in
 
 These are the canonical locations for architectural decisions; they MUST
 NOT be recorded in `CLAUDE.md` or agent-specific context files.
-
-## Active Technologies
-
-- YAML (Ansible 2.19+) + `community.general` collection + `ansible.builtin.*`;
-  Ubuntu `podman` apt package for rootless containers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,17 +216,24 @@ Built-in types and when to use each:
 | `gate`      | Async coordination checkpoint (blocks until cleared). |
 | `molecule`  | Beads work template — NOT Ansible Molecule testing.   |
 
-### Epic Gating and Attaching Issues to Epics
+### Attaching Issues to Epics (epics cannot be gated)
 
-Non-epic issues cannot block epics (`bd dep add epic non-epic` fails with
-"epics can only block other epics"). Use `--parent` instead:
+An epic cannot be excluded from `bd ready` by its children:
+
+- `bd dep add <epic> <non-epic>` is rejected ("epics can only block other
+  epics"), so a non-epic cannot block its epic.
+- `--parent` attaches a child for display/scope only. It does NOT gate
+  readiness and does NOT exclude the parent from `bd ready`.
 
 ```shell
 bd update <child-id> --parent <epic-id>
 ```
 
-This attaches the child to the epic and gates it: the epic is excluded from
-`bd ready` while any open child exists.
+An epic with open children therefore REMAINS in `bd ready`. Do not rely on
+`bd ready` exclusion to track epic scope — read the epic's CHILDREN section
+via `bd show <epic-id>` instead. See
+[triage.md](docs/architecture/concepts/issue-tracking/triage.md) for the
+validated `--parent` / `bd ready` semantics (bd v1.0.4 spike).
 
 ### Beads Dependency Wiring — Cross-Tree Follow-Ups
 

--- a/docs/architecture/concepts/issue-tracking/triage.md
+++ b/docs/architecture/concepts/issue-tracking/triage.md
@@ -57,13 +57,13 @@ bv --robot-triage --format toon  # 6. priority ranking only — never readiness
    `dep list`, or `bv unblocks_ids`.
 2. An issue absent from `bd blocked` is not blocked, regardless of `dep list`.
 3. To enforce work order, use `bd dep add`. For sub-tasks that must block their
-   epic: `bd dep add <epic> <sub-task>` (sub-task blocks epic). `--parent` alone
-   sequences nothing.
+   parent container: `bd dep add <parent> <sub-task>` (sub-task blocks parent).
+   `--parent` alone sequences nothing.
 
-   **Cycle-detector blind spot:** this hazard is not epic-specific — it applies
-   to any container. If the child was already attached with
-   `--parent <container>`, the gating `bd dep add` adds an edge antiparallel to
-   that `--parent` edge — the exact pair `bd dep cycles` cannot detect (see the
+   **Cycle-detector blind spot:** this hazard is applies to any container.
+   If the child was already attached with `--parent <container>`, the gating
+   `bd dep add` adds an edge antiparallel to that `--parent` edge — the exact
+   pair `bd dep cycles` cannot detect (see the
    [caveat above](#what-the-experiment-proved)). Do not apply this
    container-gating pattern in bulk; reserve it for deliberate one-offs and
    audit each one manually with `bd dep list <id> --direction up|down`.

--- a/docs/architecture/concepts/issue-tracking/triage.md
+++ b/docs/architecture/concepts/issue-tracking/triage.md
@@ -60,10 +60,11 @@ bv --robot-triage --format toon  # 6. priority ranking only — never readiness
    epic: `bd dep add <epic> <sub-task>` (sub-task blocks epic). `--parent` alone
    sequences nothing.
 
-   **Cycle-detector blind spot:** if the sub-task was created with
-   `--parent <epic>`, this `bd dep add` places an edge antiparallel to the
-   existing `--parent` edge — the exact pair `bd dep cycles` cannot detect
-   (see the [caveat above](#what-the-experiment-proved)). Do not apply this
+   **Cycle-detector blind spot:** this hazard is not epic-specific — it applies
+   to any container. If the child was already attached with
+   `--parent <container>`, the gating `bd dep add` adds an edge antiparallel to
+   that `--parent` edge — the exact pair `bd dep cycles` cannot detect (see the
+   [caveat above](#what-the-experiment-proved)). Do not apply this
    container-gating pattern in bulk; reserve it for deliberate one-offs and
    audit each one manually with `bd dep list <id> --direction up|down`.
 

--- a/docs/architecture/concepts/issue-tracking/triage.md
+++ b/docs/architecture/concepts/issue-tracking/triage.md
@@ -1,6 +1,7 @@
 # Issue triage and next-action determination with beads
 
-> **Validated for:** bd v1.0.4 (ce242a879) · bv v0.16.2 — 2026-06-04.
+> **Validated for:** bd v1.0.4 (ce242a879) · bv v0.16.2 — 2026-06-04;
+> dep-add type matrix re-validated 2026-06-06.
 > Re-validate after bd v1.0.5 only if its changelog mentions parent-child
 > gating, hierarchy/readiness, or `bd ready` behaviour.
 
@@ -31,17 +32,23 @@ A sandbox repo was used to change one wiring variable at a time and record
 | `--parent` (feature / task / epic) | Yes — not gated | No | No |
 | `bd dep add <blocked> <blocker>` (same type) | N/A (blocker is ready) | Yes — absent | Yes |
 | `bd dep add <sib2> <sib1>` | N/A | Yes — sib2 absent | Yes |
-| `bd dep add` across types (epic↔task) | N/A | N/A — rejected | N/A |
+| `bd dep add` non-epic cross-type (e.g. feature←task) | N/A | Yes — blocked absent | Yes |
+| `bd dep add` epic←epic | N/A | Yes | Yes |
+| `bd dep add` epic↔non-epic (either direction) | N/A | N/A — rejected | N/A |
 
 So in bd v1.0.4 `--parent` never blocks anything. It only adds the CHILDREN
 section to `bd show`, a `← parent` annotation in `bd ready`, a non-blocking
 `dep list --direction down` entry, and a (misleading) edge in `bv` graph metrics.
 
-Separately, `bd dep add` only connects two issues of the **same type**. An
-epic↔task edge is refused in both directions — "epics can only block other
-epics, not tasks" and "tasks can only block other tasks, not epics" — and a
-`--parent` link does NOT create an exception (verified epic↔task, both
-directions, with and without `--parent`).
+Separately, `bd dep add` accepts **any pair of issue types except `epic`**: an
+epic connects only to another epic. Only epic↔non-epic edges are refused — in
+**both** directions, with the same error: `Error: epics can only block other
+epics, not tasks` (printed verbatim even when the non-epic is a feature,
+milestone, or gate — the message always says "not tasks"). Every non-epic
+pairing is accepted, same- or cross-type (verified 2026-06-06: `task←task`,
+`feature←task`, `milestone←task`, `gate←task` succeed; `epic←epic` succeeds;
+`epic↔non-epic` rejected both directions). A `--parent` link neither adds nor
+removes any of these — it gates nothing.
 
 **Caveat:** `bd dep cycles` does not catch a cycle formed by mixing `--parent`
 and `bd dep add` in opposite directions between the same two issues. Audit
@@ -63,17 +70,20 @@ bv --robot-triage --format toon  # 6. priority ranking only — never readiness
 1. An issue in `bd ready` is actionable, period — regardless of `dep tree`,
    `dep list`, or `bv unblocks_ids`.
 2. An issue absent from `bd blocked` is not blocked, regardless of `dep list`.
-3. To enforce work order, use `bd dep add` — but a dep edge only connects two
-   issues of the **same type**. `bd dep add <parent> <sub-task>` gates the
-   parent only when both share a type; across types it is rejected (e.g.
-   `bd dep add <epic> <task>` → "epics can only block other epics, not tasks").
-   So a non-epic sub-task CANNOT gate its epic, and an epic CANNOT be gated out
-   of `bd ready` at all (see AGENTS.md "Attaching Issues to Epics"). `--parent`
-   alone sequences nothing and does not lift the same-type restriction.
+3. To enforce work order, use `bd dep add` — it connects **any pair of issue
+   types except `epic`**, which connects only to another epic.
+   `bd dep add <blocked> <blocker>` gates the blocked (first-arg) issue whenever
+   the pair is permitted (any non-epic pair, or epic↔epic). Tasks **can** block
+   tasks. Only epic↔non-epic is rejected — in **both** directions, emitting the
+   same error regardless of argument order or the non-epic's actual type
+   (`Error: epics can only block other epics, not tasks`). So a non-epic
+   sub-task CANNOT gate its epic, and an epic CANNOT be gated out of `bd ready`
+   by any non-epic (see AGENTS.md "Attaching Issues to Epics"). `--parent` alone
+   sequences nothing.
 
-   **Cycle-detector blind spot:** this hazard applies to any same-type
-   container/child pair (cross-type `bd dep add` is rejected, so only same-type
-   pairs can form the edge). If the child was already attached with
+   **Cycle-detector blind spot:** this hazard applies to ANY pair that can form
+   a `bd dep add` edge — any non-epic pair (same- or cross-type) and epic↔epic.
+   If the child was already attached with
    `--parent <container>`, the gating `bd dep add` adds an edge antiparallel to
    that `--parent` edge — the exact pair `bd dep cycles` cannot detect (see the
    [caveat above](#what-the-experiment-proved)). Do not apply this
@@ -82,4 +92,5 @@ bv --robot-triage --format toon  # 6. priority ranking only — never readiness
 
 ---
 
-*Derived from the bd/bv semantics spike (`ansible-all-my-things-8p1t`).*
+*Derived from a bd/bv semantics spike (sandbox experiment, 2026-06-04;
+dep-add type matrix re-validated 2026-06-06).*

--- a/docs/architecture/concepts/issue-tracking/triage.md
+++ b/docs/architecture/concepts/issue-tracking/triage.md
@@ -60,6 +60,13 @@ bv --robot-triage --format toon  # 6. priority ranking only — never readiness
    epic: `bd dep add <epic> <sub-task>` (sub-task blocks epic). `--parent` alone
    sequences nothing.
 
+   **Cycle-detector blind spot:** if the sub-task was created with
+   `--parent <epic>`, this `bd dep add` places an edge antiparallel to the
+   existing `--parent` edge — the exact pair `bd dep cycles` cannot detect
+   (see the [caveat above](#what-the-experiment-proved)). Do not apply this
+   container-gating pattern in bulk; reserve it for deliberate one-offs and
+   audit each one manually with `bd dep list <id> --direction up|down`.
+
 ---
 
 *Derived from the bd/bv semantics spike (`ansible-all-my-things-8p1t`).*

--- a/docs/architecture/concepts/issue-tracking/triage.md
+++ b/docs/architecture/concepts/issue-tracking/triage.md
@@ -29,12 +29,19 @@ A sandbox repo was used to change one wiring variable at a time and record
 | Wiring | Parent in `bd ready`? | Child gated? | In `bd blocked`? |
 | --- | --- | --- | --- |
 | `--parent` (feature / task / epic) | Yes — not gated | No | No |
-| `bd dep add <blocked> <blocker>` | N/A (blocker is ready) | Yes — absent | Yes |
+| `bd dep add <blocked> <blocker>` (same type) | N/A (blocker is ready) | Yes — absent | Yes |
 | `bd dep add <sib2> <sib1>` | N/A | Yes — sib2 absent | Yes |
+| `bd dep add` across types (epic↔task) | N/A | N/A — rejected | N/A |
 
 So in bd v1.0.4 `--parent` never blocks anything. It only adds the CHILDREN
 section to `bd show`, a `← parent` annotation in `bd ready`, a non-blocking
 `dep list --direction down` entry, and a (misleading) edge in `bv` graph metrics.
+
+Separately, `bd dep add` only connects two issues of the **same type**. An
+epic↔task edge is refused in both directions — "epics can only block other
+epics, not tasks" and "tasks can only block other tasks, not epics" — and a
+`--parent` link does NOT create an exception (verified epic↔task, both
+directions, with and without `--parent`).
 
 **Caveat:** `bd dep cycles` does not catch a cycle formed by mixing `--parent`
 and `bd dep add` in opposite directions between the same two issues. Audit
@@ -56,14 +63,19 @@ bv --robot-triage --format toon  # 6. priority ranking only — never readiness
 1. An issue in `bd ready` is actionable, period — regardless of `dep tree`,
    `dep list`, or `bv unblocks_ids`.
 2. An issue absent from `bd blocked` is not blocked, regardless of `dep list`.
-3. To enforce work order, use `bd dep add`. For sub-tasks that must block their
-   parent container: `bd dep add <parent> <sub-task>` (sub-task blocks parent).
-   `--parent` alone sequences nothing.
+3. To enforce work order, use `bd dep add` — but a dep edge only connects two
+   issues of the **same type**. `bd dep add <parent> <sub-task>` gates the
+   parent only when both share a type; across types it is rejected (e.g.
+   `bd dep add <epic> <task>` → "epics can only block other epics, not tasks").
+   So a non-epic sub-task CANNOT gate its epic, and an epic CANNOT be gated out
+   of `bd ready` at all (see AGENTS.md "Attaching Issues to Epics"). `--parent`
+   alone sequences nothing and does not lift the same-type restriction.
 
-   **Cycle-detector blind spot:** this hazard is applies to any container.
-   If the child was already attached with `--parent <container>`, the gating
-   `bd dep add` adds an edge antiparallel to that `--parent` edge — the exact
-   pair `bd dep cycles` cannot detect (see the
+   **Cycle-detector blind spot:** this hazard applies to any same-type
+   container/child pair (cross-type `bd dep add` is rejected, so only same-type
+   pairs can form the edge). If the child was already attached with
+   `--parent <container>`, the gating `bd dep add` adds an edge antiparallel to
+   that `--parent` edge — the exact pair `bd dep cycles` cannot detect (see the
    [caveat above](#what-the-experiment-proved)). Do not apply this
    container-gating pattern in bulk; reserve it for deliberate one-offs and
    audit each one manually with `bd dep list <id> --direction up|down`.


### PR DESCRIPTION
## Summary

- Corrects AGENTS.md epic-gating section: `bd dep add` rejects **both** directions of epic↔non-epic, not just one; `--parent` does NOT gate readiness
- De-duplicates language/skill-index rules in AGENTS.md (two near-identical blocks merged)
- Extends `triage.md` dep-add type matrix with cross-type and epic rows, re-validated 2026-06-06
- Expands cycle-detector blind-spot warning to cover all eligible `bd dep add` pairs, not just container-gating

## Test plan

- [ ] Verify AGENTS.md epic-gating section matches bd v1.0.4 behaviour (both rejection directions documented)
- [ ] Verify triage.md dep-add matrix covers all tested combinations
- [ ] Confirm no duplicate rule blocks remain in AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)