### PR TITLE
refactor: remove ambient curl from claude_code molecule scenario

### DIFF
--- a/playbooks/files/docker/Dockerfile
+++ b/playbooks/files/docker/Dockerfile
@@ -1,5 +1,24 @@
 # Docker provider VM image: systemd-enabled Ubuntu with sshd, root/password
 # auth. Run with `docker run --privileged ...` so systemd can manage cgroups.
+#
+# Package policy: this image is a *managed-node* surrogate — a local stand-in
+# for a fresh AWS/Hetzner cloud VM that Ansible connects to and configures. It
+# is NOT the control node (.devcontainer image, which carries ansible/aws-cli/
+# hcloud/git/gpg). Keep this image to the minimum a cloud VM presents so local
+# tests stay at least as strict as the real target: a role that forgets a tool
+# prereq must fail HERE, not slip through because the image happened to ship it.
+#
+# Therefore tool prereqs (curl, git, unzip, gpg, ...) are NOT baked in — each
+# role installs its own (e.g. roles/java installs zip/unzip/curl). curl in
+# particular is deliberately absent: it was once added to paper over roles that
+# assumed an ambient curl; those roles instead use ansible.builtin.get_url
+# (native, idempotent, fails loud) or install curl themselves.
+#
+# Exception — ca-certificates IS kept: it is shared TLS trust *substrate*, not a
+# tool. ~10 roles use get_url over HTTPS and rely on the system CA store;
+# installing it per-role would duplicate it everywhere (DRY), and every real
+# cloud Ubuntu image ships it. systemd/sshd/sudo/python3 are likewise the
+# connection substrate Ansible cannot bootstrap over.
 FROM ubuntu:24.04
 
 ARG DOCKER_ROOT_PASSWORD
@@ -12,6 +31,7 @@ RUN apt-get update \
         sudo \
         dbus \
         python3 \
+        ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/playbooks/setup-nodejs.yml
+++ b/playbooks/setup-nodejs.yml
@@ -1,16 +1,22 @@
 ---
 - hosts: linux
   become: true
-  
+
   vars:
     ansible_user: "{{ my_ansible_user }}"
     desktop_user_names: "{{ desktop_users | map(attribute='name') | list }}"
     first_desktop_user: "{{ desktop_user_names[0] }}"
 
   tasks:
+    - name: Download NVM install script
+      ansible.builtin.get_url:
+        url: https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh
+        dest: /tmp/nvm-install.sh
+        mode: '0755'
+
     - name: Install NVM
-      shell: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
-      args:
+      ansible.builtin.shell:
+        cmd: /tmp/nvm-install.sh
         creates: "/home/{{ item }}/.nvm/nvm.sh"
       become_user: "{{ item }}"
       loop: "{{ desktop_user_names }}"
@@ -54,7 +60,7 @@
           markdownlint-cli \
           prettier \
           typescript
-      # Note: Last package is used in the `creates` check below for idempotency. 
+      # Note: Last package is used in the `creates` check below for idempotency.
       args:
         executable: /bin/bash
         creates: "/home/{{ item }}/.nvm/versions/node/{{ nvm_current_output.stdout_lines[0] }}/lib/node_modules/typescript"

--- a/roles/claude_code/README.md
+++ b/roles/claude_code/README.md
@@ -13,7 +13,6 @@ for web search.
 
 - Ansible 2.19+
 - `git` present on target hosts (not managed by this role)
-- `curl` present on target hosts (used by the beads installer)
 - Internet access from target hosts (downloads Claude Code, plugins, beads)
 
 ## Role Variables

--- a/roles/claude_code/molecule/default/Dockerfile
+++ b/roles/claude_code/molecule/default/Dockerfile
@@ -2,5 +2,5 @@ FROM docker.io/library/ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq \
     && apt-get install -y -qq --no-install-recommends \
-       python3 sudo git curl ca-certificates pipx \
+       python3 sudo git ca-certificates pipx \
     && rm -rf /var/lib/apt/lists/*

--- a/roles/claude_code/molecule/default/prepare.yml
+++ b/roles/claude_code/molecule/default/prepare.yml
@@ -19,15 +19,25 @@
         group: testuser
         mode: '0755'
 
+    - name: Download NVM install script
+      ansible.builtin.get_url:
+        url: https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh
+        dest: /tmp/nvm-install.sh
+        mode: '0755'
+
     - name: Install nvm for testuser
-      ansible.builtin.shell: curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/HEAD/install.sh | bash
-      args:
-        executable: /bin/bash
+      ansible.builtin.shell:
+        cmd: /tmp/nvm-install.sh
         creates: /home/testuser/.nvm/nvm.sh
-      become: true
       become_user: testuser
       environment:
         HOME: /home/testuser
+
+    - name: Install curl for nvm runtime
+      ansible.builtin.apt:
+        name: curl
+        state: present
+        update_cache: true
 
     - name: Install Node.js LTS via nvm
       ansible.builtin.shell: source /home/testuser/.nvm/nvm.sh && nvm install --lts

--- a/roles/claude_code/molecule/default/prepare.yml
+++ b/roles/claude_code/molecule/default/prepare.yml
@@ -43,7 +43,6 @@
       ansible.builtin.shell: source /home/testuser/.nvm/nvm.sh && nvm install --lts
       args:
         executable: /bin/bash
-      become: true
       become_user: testuser
       environment:
         HOME: /home/testuser

--- a/roles/claude_code/tasks/install-addons.yml
+++ b/roles/claude_code/tasks/install-addons.yml
@@ -19,9 +19,16 @@
 # Install beads issue tracker for each desktop user
 # -----
 
+- name: Download beads install script
+  ansible.builtin.get_url:
+    url: https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh
+    dest: /tmp/beads-install.sh
+    mode: '0755'
+  become: true
+
 - name: Install beads issue tracker
   ansible.builtin.shell:
-    cmd: curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+    cmd: /tmp/beads-install.sh
     creates: /home/{{ item }}/.local/bin/bd
   become: true
   become_user: "{{ item }}"
@@ -29,9 +36,16 @@
     PATH: "/home/{{ item }}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   loop: "{{ desktop_user_names }}"
 
+- name: Download beads viewer install script
+  ansible.builtin.get_url:
+    url: https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh
+    dest: /tmp/beads-viewer-install.sh
+    mode: '0755'
+  become: true
+
 - name: Install beads viewer
   ansible.builtin.shell:
-    cmd: curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh" | bash
+    cmd: /tmp/beads-viewer-install.sh
     creates: /home/{{ item }}/.local/bin/bv
   become: true
   become_user: "{{ item }}"

--- a/specs/012-hcloud-vm-provider/tasks.md
+++ b/specs/012-hcloud-vm-provider/tasks.md
@@ -320,7 +320,7 @@ unchanged.
 
 **Purpose**: Repository-wide closing tasks mandated by the constitution.
 
-- [ ] T011 Run `review-documentation-here` then `format-markdown` across any
+- [x] T011 Run `review-documentation-here` then `format-markdown` across any
   Markdown touched by this feature (constitution Principle VI and
   Documentation Standards). Confirm `playbooks/vars/hostname_pool_hcloud.yml`'s
   header comment and the two task files' algorithm comments are consistent


### PR DESCRIPTION
## Summary

- `prepare.yml`: converts NVM bootstrap from `curl|bash` to `ansible.builtin.get_url` + `shell` (pinned v0.40.3), eliminating the pipe-to-bash anti-pattern
- `Dockerfile`: removes `curl` from the apt install list so the molecule container no longer ships curl as an ambient tool
- `prepare.yml`: explicitly installs `curl` via apt before `nvm install --lts` (NVM requires curl at runtime to download Node.js; the NVM bootstrap itself uses git which is already present)
- Removes redundant per-task `become: true` (play-level `become: true` already covers all tasks)

Both changes together make molecule tests as strict as the real cloud target: a role that forgets a curl prereq will now fail in the container rather than silently passing because the image happened to ship it.

## Test plan

- [x] `molecule test` passes locally (all stages: destroy → syntax → create → prepare → converge → idempotence → verify → destroy)
- [x] GitHub Actions Molecule Tests CI passed on `eudicy:main`