### PR TITLE
fix: NVM and claude_code role missing prerequisites on fresh hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@
 .worktrees/
 
 # Oh My Claude Code
-.omc/state/
-.omc/sessions/
+**/.omc/state/
+**/.omc/sessions/
 .omc/prd.json
 .omc/project-memory.json
 .omc/progress.txt

--- a/playbooks/configure-profile-roles.yml
+++ b/playbooks/configure-profile-roles.yml
@@ -1,6 +1,6 @@
 ---
 - name: Configure basic profile linux roles
-  hosts: tart
+  hosts: linux
   become: true
 
   vars:

--- a/playbooks/setup-nodejs.yml
+++ b/playbooks/setup-nodejs.yml
@@ -8,6 +8,12 @@
     first_desktop_user: "{{ desktop_user_names[0] }}"
 
   tasks:
+    - name: Install curl
+      ansible.builtin.apt:
+        name: curl
+        state: present
+        update_cache: true
+
     - name: Download NVM install script
       ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh

--- a/roles/claude_code/.omc/state/agent-replay-2f0724e2-381b-4ea1-b232-8f6f9fccb4a8.jsonl
+++ b/roles/claude_code/.omc/state/agent-replay-2f0724e2-381b-4ea1-b232-8f6f9fccb4a8.jsonl
@@ -1,2 +1,0 @@
-{"t":0,"agent":"a995392","agent_type":"unknown","event":"agent_stop","success":true}
-{"t":0,"agent":"ad7e71e","agent_type":"unknown","event":"agent_stop","success":true}

--- a/roles/claude_code/.omc/state/last-tool-error.json
+++ b/roles/claude_code/.omc/state/last-tool-error.json
@@ -1,7 +1,0 @@
-{
-  "tool_name": "Bash",
-  "tool_input_preview": "{\"command\":\"bd add \\\"Adapt agent rules and skills to AI agent workspace changes\\\" --body \\\"Adapting the agent rules and skills to reflect recent changes made in the AI agent workspace. This includes u...",
-  "error": "Exit code 1\nError: unknown command \"add\" for \"bd\"\n\nDid you mean this?\n\tado\n\nRun 'bd --help' for usage.",
-  "timestamp": "2026-05-08T03:54:44.657Z",
-  "retry_count": 1
-}

--- a/roles/claude_code/.omc/state/subagent-tracking.json
+++ b/roles/claude_code/.omc/state/subagent-tracking.json
@@ -1,7 +1,0 @@
-{
-  "agents": [],
-  "total_spawned": 0,
-  "total_completed": 0,
-  "total_failed": 0,
-  "last_updated": "2026-05-08T03:57:13.181Z"
-}

--- a/roles/claude_code/molecule/default/Dockerfile
+++ b/roles/claude_code/molecule/default/Dockerfile
@@ -2,5 +2,5 @@ FROM docker.io/library/ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq \
     && apt-get install -y -qq --no-install-recommends \
-       python3 sudo git ca-certificates pipx \
+       python3 sudo ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/roles/claude_code/molecule/default/prepare.yml
+++ b/roles/claude_code/molecule/default/prepare.yml
@@ -25,6 +25,12 @@
         dest: /tmp/nvm-install.sh
         mode: '0755'
 
+    - name: Install curl for nvm runtime
+      ansible.builtin.apt:
+        name: curl
+        state: present
+        update_cache: true
+
     - name: Install nvm for testuser
       ansible.builtin.shell:
         cmd: /tmp/nvm-install.sh
@@ -32,12 +38,6 @@
       become_user: testuser
       environment:
         HOME: /home/testuser
-
-    - name: Install curl for nvm runtime
-      ansible.builtin.apt:
-        name: curl
-        state: present
-        update_cache: true
 
     - name: Install Node.js LTS via nvm
       ansible.builtin.shell: source /home/testuser/.nvm/nvm.sh && nvm install --lts

--- a/roles/claude_code/tasks/install-deps.yml
+++ b/roles/claude_code/tasks/install-deps.yml
@@ -1,20 +1,11 @@
 #SPDX-License-Identifier: MIT-0
 ---
-- name: Install jq
+- name: Install jq, git and pipx
   ansible.builtin.apt:
-    name: jq
-    state: present
-  become: true
-
-- name: Install git
-  ansible.builtin.apt:
-    name: git
-    state: present
-  become: true
-
-- name: Install pipx
-  ansible.builtin.apt:
-    name: pipx
+    name:
+      - jq
+      - git
+      - pipx
     state: present
   become: true
 

--- a/roles/claude_code/tasks/install-deps.yml
+++ b/roles/claude_code/tasks/install-deps.yml
@@ -12,6 +12,12 @@
     state: present
   become: true
 
+- name: Install pipx
+  ansible.builtin.apt:
+    name: pipx
+    state: present
+  become: true
+
 - name: Check if rtk binary already exists
   ansible.builtin.stat:
     path: /usr/local/bin/rtk

--- a/roles/claude_code/tasks/install-deps.yml
+++ b/roles/claude_code/tasks/install-deps.yml
@@ -6,6 +6,12 @@
     state: present
   become: true
 
+- name: Install git
+  ansible.builtin.apt:
+    name: git
+    state: present
+  become: true
+
 - name: Check if rtk binary already exists
   ansible.builtin.stat:
     path: /usr/local/bin/rtk


### PR DESCRIPTION
## Summary

- `setup-nodejs.yml` failed on a fresh host with "You need git, curl, or wget to install nvm" — added a curl prerequisite task.
- `roles/claude_code` failed on a fresh host with "Failed to find required executable git" — added git (and the related missing pipx) as role-installed prerequisites.
- `roles/claude_code`'s molecule Dockerfile baked in git/pipx, which had been masking both gaps from local testing. Removed them so the role's own prerequisite installs are actually exercised, and fixed `prepare.yml`'s curl/nvm task ordering.
- Combined the role's jq/git/pipx apt installs into a single task.

## Test plan

- [x] `molecule test` passes full lifecycle for `roles/claude_code` (create → prepare → converge → idempotence → verify → destroy)
- [x] `ansible-playbook playbooks/configure-profile.yml -l <host>` succeeds on a fresh docker host
- [x] `ansible-playbook playbooks/configure-profile-roles.yml -l <host>` succeeds on a fresh docker host
- [x] Second run of both playbooks is idempotent (changed=0)

🤖 Generated with [Claude Code](https://claude.ai/code)