### PR TITLE
fix: backup playbooks failed with cryptic error when run without -e backup_from_host

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Follow setup instructions in
 - [Create Virtual Machines](./docs/user-manual/create-vm.md)
 - [Important Concepts](./docs/user-manual/important-concepts.md)
 - [Work with a VM](./docs/user-manual/work-with-vm.md)
+- [Backup and Restore](./docs/user-manual/backup-restore.md)
 - [Synchronize Git Repositories with a VM](./docs/user-manual/synchronize-repos-with-vm.md)
 
 ## Documentation

--- a/backup.yml
+++ b/backup.yml
@@ -1,7 +1,7 @@
 ---
 # The host to back up is configured via the `backup_from_host` variable.
-# The default is set in inventories/group_vars/all/vars.yml.
-# Override at runtime with: ansible-playbook backup.yml -e backup_from_host=hobbiton
+# This variable has no default and MUST be set at runtime, e.g.:
+# ansible-playbook backup.yml -e backup_from_host=hobbiton
 
 # Per user configuration
 - import_playbook: playbooks/backup/home-folder-files.yml

--- a/docs/user-manual/backup-restore.md
+++ b/docs/user-manual/backup-restore.md
@@ -1,0 +1,54 @@
+# Backup and Restore
+
+## Backup the working directory of the desktop user
+
+`backup.yml` backs up the working directory and application settings of the
+first desktop user listed in
+[/inventories/group_vars/all/vars.yml](../inventories/group_vars/all/vars.yml).
+
+The backup source host has no default — it must always be passed explicitly
+with `-e backup_from_host=<host>`:
+
+```shell
+ansible-playbook ./backup.yml -e backup_from_host=hobbiton
+```
+
+See [/backup.yml](../backup.yml) for why no default exists, and
+[/playbooks/backup/](../playbooks/backup/) for the per-application playbooks
+it imports (Chromium, VS Code, Cursor, RTK, keyring, and more).
+
+## Restore a backup of the desktop user
+
+> [!ATTENTION]
+> The same backup is restored for all users
+
+Restoring the backup is part of the [/configure.yml](../configure.yml)
+playbook and runs automatically during `provision.yml` /
+`configure-linux.yml`.
+
+To restore a backup later manually, use the following command. Unlike
+backup, restore always targets the `linux` host group, so no `-e` flag is
+required:
+
+```shell
+ansible-playbook ./restore.yml
+```
+
+See [/playbooks/restore/](../playbooks/restore/) for the per-application
+playbooks it imports.
+
+## After Restore
+
+Two steps cannot be automated and must be done manually afterward:
+
+```shell
+claude login
+```
+
+```shell
+omc setup
+```
+
+---
+
+Previous: [Work with a Virtual Machine](./work-with-vm.md)

--- a/docs/user-manual/backup-restore.md
+++ b/docs/user-manual/backup-restore.md
@@ -4,7 +4,7 @@
 
 `backup.yml` backs up the working directory and application settings of the
 first desktop user listed in
-[/inventories/group_vars/all/vars.yml](../inventories/group_vars/all/vars.yml).
+[/inventories/group_vars/all/vars.yml](../../inventories/group_vars/all/vars.yml).
 
 The backup source host has no default — it must always be passed explicitly
 with `-e backup_from_host=<host>`:
@@ -13,18 +13,18 @@ with `-e backup_from_host=<host>`:
 ansible-playbook ./backup.yml -e backup_from_host=hobbiton
 ```
 
-See [/backup.yml](../backup.yml) for why no default exists, and
-[/playbooks/backup/](../playbooks/backup/) for the per-application playbooks
-it imports (Chromium, VS Code, Cursor, RTK, keyring, and more).
+See [/backup.yml](../../backup.yml) for why no default exists, and
+[/playbooks/backup/](../../playbooks/backup/) for the per-application
+playbooks it imports (Chromium, VS Code, RTK, keyring, and more).
 
 ## Restore a backup of the desktop user
 
 > [!ATTENTION]
 > The same backup is restored for all users
 
-Restoring the backup is part of the [/configure.yml](../configure.yml)
-playbook and runs automatically during `provision.yml` /
-`configure-linux.yml`.
+Restoring the backup is part of the
+[/configure-linux.yml](../../configure-linux.yml) playbook and runs
+automatically during `provision.yml`.
 
 To restore a backup later manually, use the following command. Unlike
 backup, restore always targets the `linux` host group, so no `-e` flag is
@@ -34,7 +34,7 @@ required:
 ansible-playbook ./restore.yml
 ```
 
-See [/playbooks/restore/](../playbooks/restore/) for the per-application
+See [/playbooks/restore/](../../playbooks/restore/) for the per-application
 playbooks it imports.
 
 ## After Restore

--- a/docs/user-manual/create-vm.md
+++ b/docs/user-manual/create-vm.md
@@ -155,13 +155,10 @@ Connect via an RDP compatible client. For Linux, use the `galadriel` user, on Wi
 
 ## Delete the VM
 
-To delete the VM and all associated resources, use the following command:
+To delete the VM and all associated resources, back up your configuration
+first — see [Backup and Restore](./backup-restore.md) — then destroy:
 
 ```shell
-# Backup your configuration
-ansible-playbook ./backup.yml
-
-# Destroy
 ansible-playbook ./destroy.yml
 ```
 

--- a/docs/user-manual/work-with-vm.md
+++ b/docs/user-manual/work-with-vm.md
@@ -25,40 +25,12 @@ Now you can open an RDP client like Remmina, Windows App or Remote Desktop to co
 
 The GNOME keyring needs to be unlocked when you launch an application using it, e.g. Visual Studio Code. The password is configured in [/inventories/group_vars/all/vault.yml](../inventories/group_vars/all/vault.yml).
 
-## Backup working directory of desktop user
+## Backup and restore
 
-To backup the working directory of the first desktop user listed in [/inventories/group_vars/all/vars.yml](../inventories/group_vars/all/vars.yml), use the following command:
-
-```shell
-ansible-playbook ./backup.yml
-```
-
-## Restore a backup of the desktop user
-
-> [!ATTENTION]
-> The same backup is restored for all users
-
-Restoring the backup is a part of the [../configure.yml](../configure.yml) playbook.
-
-To restore a backup later manually, use the following command:
-
-```shell
-ansible-playbook ./restore.yml
-```
-
-## After Restore
-
-`provision.yml` / `configure-linux.yml` run the restore automatically.
-Two steps cannot be automated and must be done manually afterward:
-
-```shell
-claude login
-```
-
-```shell
-omc setup
-```
+See [Backup and Restore](./backup-restore.md) for backing up the desktop
+user's working directory and restoring it later.
 
 ---
 
 Previous: [Create a Virtual Machine](./create-vm.md)
+Next: [Backup and Restore](./backup-restore.md)

--- a/inventories/group_vars/all/vars.yml
+++ b/inventories/group_vars/all/vars.yml
@@ -27,11 +27,6 @@ gnome_keyring_password: "{{ vault_gnome_keyring_password }}"
 # Windows Server Administrator password (for AWS Windows instances)
 windows_admin_password: "{{ vault_windows_admin_password }}"
 
-# Host to back up for backup playbooks (playbooks/backup/).
-# REQUIRED at runtime -- there is no working default, because a play's
-# hosts: field is templated before group_vars load. Pass it explicitly:
-#   ansible-playbook backup.yml -e backup_from_host=hobbiton
-
 # The following users will be created on the desktop system.
 # Add as many users as you like. There should be at least one user.
 desktop_users:

--- a/inventories/group_vars/all/vars.yml
+++ b/inventories/group_vars/all/vars.yml
@@ -27,9 +27,10 @@ gnome_keyring_password: "{{ vault_gnome_keyring_password }}"
 # Windows Server Administrator password (for AWS Windows instances)
 windows_admin_password: "{{ vault_windows_admin_password }}"
 
-# Default host for backup playbooks (playbooks/backup/).
-# Override at runtime with: -e backup_from_host=hobbiton
-backup_from_host: "vulcan"
+# Host to back up for backup playbooks (playbooks/backup/).
+# REQUIRED at runtime -- there is no working default, because a play's
+# hosts: field is templated before group_vars load. Pass it explicitly:
+#   ansible-playbook backup.yml -e backup_from_host=hobbiton
 
 # The following users will be created on the desktop system.
 # Add as many users as you like. There should be at least one user.


### PR DESCRIPTION
## Summary
- A play's `hosts:` field is templated before `group_vars` loads, so `backup_from_host`'s group_vars/all default was never actually in scope — every plain `ansible-playbook backup.yml` (no `-e`) failed with a cryptic `'backup_from_host' is undefined` error.
- Removed the decoy default from `inventories/group_vars/all/vars.yml` and corrected its comment plus `backup.yml`'s banner to state the `-e backup_from_host=<host>` override is mandatory — zero `playbooks/backup/*.yml` files touched (avoids duplicating a host literal across 8 playbooks).
- Added `docs/user-manual/backup-restore.md` as a single source of truth for backup/restore usage, retiring stale/duplicated inline instructions in `work-with-vm.md` and `create-vm.md` that showed the same broken bare command.
- Reviewed via ralplan consensus (Planner → Architect → Critic) plus a separate post-implementation Architect + Critic pass that caught and fixed broken doc links and a stale claim.

Already merged and validated on the fork: eudicy/ansible-all-my-things#39

## Test plan
- [x] `ansible-playbook --syntax-check -e backup_from_host=dagorlad` passes on all 8 leaf playbooks + root `./backup.yml`
- [x] Negative run: `ansible-playbook ./backup.yml --list-hosts` (no `-e`) exits non-zero with `Error processing keyword 'hosts': 'backup_from_host' is undefined`
- [x] Positive run: `ansible-playbook ./backup.yml --list-hosts -e backup_from_host=dagorlad` exits 0, lists `hosts (1): dagorlad` for all 7 active plays
- [x] Same negative/positive pair run directly against `playbooks/backup/cursor-settings.yml` (the one leaf not reachable via the aggregator)
- [x] All new/changed Markdown lint-clean (`markdownlint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)