### PR TITLE
feat: install OpenCode AI CLI; sync roadmap + backup/restore refactor

### DIFF
--- a/docs/feature-requests/feat.create-destroy-vm/roadmap.md
+++ b/docs/feature-requests/feat.create-destroy-vm/roadmap.md
@@ -190,14 +190,72 @@ conflict-free, group-scoped base.
   exists — see the Phase 6 section below for the evidence
   (ansible-all-my-things-h6f3).
 
-### Phase 6 — Retire superseded artefacts (migration) (NOT STARTED)
+### Phase 5b — `windows` profile, aws-only (DONE)
 
-Depends on (a) every provider that `provision.yml` / `destroy.yml` currently
+Tracked in `specs/015-aws-windows-profile/`. Adds a third profile —
+`windows`, restricted to `provider=aws` (no local provider has a Windows
+equivalent) — bringing the legacy `provisioners/aws-windows.yml` Windows
+Server capability into the unified `create-vm.yml` / `destroy-vm.yml` /
+`configure-profile.yml` command shape:
+
+- `tasks/assert-provider-profile.yml`: accepts `profile=windows` and
+  loudly rejects it for any provider other than `aws`.
+- `tasks/create/aws.yml`: a `profile == 'windows'` branch resolves
+  Windows AMI/instance-type defaults, generates the Administrator
+  `user_data` PowerShell bootstrap (OpenSSH + PowerShell shell, ported from
+  the legacy script), widens the `3389` (RDP) security-group rule to
+  `profile in ['desktop', 'windows']`, and registers the host under a
+  `windows` inventory group (`ansible_user: Administrator`) distinct from
+  `linux`/`basic`/`desktop`.
+- `tasks/destroy/aws.yml`: cleans up the `windows` group key alongside the
+  existing `linux`/`basic`/`desktop` cleanup.
+- `configure-profile.yml`: imports the legacy `setup-roles-windows.yml`
+  (`windows_foundation` + `win_ai_agent` roles) unconditionally — safe
+  because that file already scopes itself to `hosts: windows`.
+  `setup-users.yml` / `setup-basics.yml` / `reboot-if-required.yml` were
+  re-scoped from `hosts: all` to `hosts: linux` so they no longer reach
+  the new `windows` group.
+- Windows has no local equivalent (Constitution Principle III's "local
+  provider" carve-out does not exist for this OS), so validation ran
+  directly against real AWS. That validation surfaced and fixed two
+  real bugs, now folded into the `developer` skill's Known Gotchas:
+  module-execution readiness probes (`wait_for_connection`) never succeed
+  over plain `ssh` against Windows (no Python at boot), so AWS Windows
+  readiness uses a TCP-level `wait_for: port=22` check instead, with a
+  longer boot-readiness budget than Linux.
+
+**Known follow-up (not blocking)**: `setup-roles-windows.yml` lists both
+`windows_foundation` and `win_ai_agent` as roles, and `win_ai_agent`'s own
+meta dependency also pulls in `windows_foundation` — so its tasks
+(RDP tuning, Chocolatey install, reboot) run twice per
+`configure-profile.yml` pass. Likely harmless beyond wasted time and an
+extra reboot; fixing it means touching the legacy
+`setup-roles-windows.yml`/role-meta files, which is out of scope for this
+phase per its FR-013 (tracked in ansible-all-my-things-1ke3).
+
+**Value**: full provider/profile parity for Windows — an engineer
+provisions a disposable Windows Server box (SSH + RDP, Claude Code, nvm,
+Node.js LTS) through the same unified command already used for every Linux
+target.
+
+### Phase 6 — Retire superseded artefacts (migration) (READY TO START)
+
+Depended on (a) every provider that `provision.yml` / `destroy.yml` currently
 serves having a working replacement under `create-vm.yml` / `destroy-vm.yml`,
 **and** (b) the `desktop` profile (Phase 5) being functionally equivalent
 under the new playbooks — including a demonstrated
 backup → destroy → create → restore round-trip of `restore.yml` on the new
-playbooks (ported **and** proven, not merely ported).
+playbooks (ported **and** proven, not merely ported), **and** (c) the
+`windows` profile (Phase 5b, DONE) already covering create/destroy/configure
+parity with legacy `provisioners/aws-windows.yml` / `configure-windows.yml`.
+
+**All three gates are now cleared (2026-06-24)**: (a) and (c) were proven by
+Phase 4 and Phase 5b respectively; (b)'s round-trip gate issue
+(`ansible-all-my-things-75nv`) is closed, referencing the proof below. The
+only items still open under epic `ansible-all-my-things-yyoy` are
+`ansible-all-my-things-kcp1` (P3, narrowing `hosts:` in the 7 restore/backup
+playbooks — a cleanup, not a parity gap) and the epic itself (closable only
+by the user). Nothing blocks starting Phase 6's deletion work.
 
 **Round-trip gate PROVEN on Tart (local), 2026-06-21** (tracked in
 ansible-all-my-things-h6f3): `create(romulus, desktop)` →
@@ -227,10 +285,12 @@ just `restore.yml`/`backup.yml` as originally assumed.
 Delete
 `provision.yml`, `destroy.yml`, `provisioners/`, the legacy
 `configure-linux.yml` / `configure-linux-roles.yml` / `setup-desktop.yml` /
-`setup-keyring.yml` / `setup-desktop-apps.yml` entrypoints, and the legacy
-static inventory files (`inventories/vagrant_tart.yml`,
-`inventories/vagrant_docker.yml`, `inventories/hcloud.yml`). Update
-`docs/user-manual/create-vm.md`; remove all user-facing references to
+`setup-keyring.yml` / `setup-desktop-apps.yml` / `configure-windows.yml`
+entrypoints, and the legacy static inventory files
+(`inventories/vagrant_tart.yml`, `inventories/vagrant_docker.yml`,
+`inventories/hcloud.yml`). `setup-roles-windows.yml` stays — it is still
+imported by `configure-profile.yml` (Phase 5b), not a superseded artefact.
+Update `docs/user-manual/create-vm.md`; remove all user-facing references to
 `provision.yml` / `destroy.yml`.
 
 **Value**: a single, consistent VM-lifecycle mechanism with no legacy
@@ -246,17 +306,20 @@ Phase 1 (tart, DONE)
                         │
                         ├─> provider parity (all 4 providers) ─────┐
                         │                                          │
-                        └─> Phase 5 (desktop profile, DONE,        ┤
-                            round-trip proven) desktop parity ─────┤
+                        ├─> Phase 5 (desktop profile, DONE,        ┤
+                        │   round-trip proven) desktop parity ─────┤
+                        │                                          │
+                        └─> Phase 5b (windows profile, DONE,       ┤
+                            aws-only) windows parity ──────────────┤
                                                                    v
-                                              Phase 6 (retire legacy, NOT STARTED)
+                                              Phase 6 (retire legacy, READY TO START)
 ```
 
 Phase 6 (deletion) depends on every provider that `provision.yml` /
 `destroy.yml` currently serves having a working replacement under the new
-playbooks, **and** on Phase 5 (the `desktop` profile) reaching parity with
-the legacy stack — the desktop profile is not an independent, skippable
-branch of this graph.
+playbooks, **and** on Phase 5 (the `desktop` profile) and Phase 5b (the
+`windows` profile) reaching parity with the legacy stack — neither profile is
+an independent, skippable branch of this graph.
 
 ## Outlook: podman as a third local provider
 

--- a/playbooks/configure-profile-roles.yml
+++ b/playbooks/configure-profile-roles.yml
@@ -14,6 +14,7 @@
     - python
     - dolt_sql_server
     - claude_code
+    - opencode
 
 - name: Configure desktop profile linux roles
   hosts: desktop
@@ -31,6 +32,7 @@
     - ruby
     - python
     - claude_code
+    - opencode
     - tmux
     - nerd_font
     - dolt_sql_server

--- a/playbooks/update-versions/perform-updates.yml
+++ b/playbooks/update-versions/perform-updates.yml
@@ -60,6 +60,15 @@
       ansible.builtin.set_fact:
         fetched_dolt_tag: "{{ fetched_github_tag }}"
 
+    - name: Fetch OpenCode upstream version
+      ansible.builtin.include_tasks: tasks/fetch-github-release.yml
+      vars:
+        github_repo: "anomalyco/opencode"
+
+    - name: Save OpenCode fetched tag
+      ansible.builtin.set_fact:
+        fetched_opencode_tag: "{{ fetched_github_tag }}"
+
     # --- Apply updates to role defaults files ---
 
     # Flutter SDK: version and sha256 updated together
@@ -153,3 +162,47 @@
         path: "{{ _roles_dir }}/dolt_sql_server/defaults/main.yml"
         regexp: 'dolt_sha256_arm64:\s*"[^"]+"'
         replace: 'dolt_sha256_arm64: "{{ _dolt_arm64_stat.stat.checksum }}"'
+
+    - name: Update opencode_version in opencode role defaults
+      ansible.builtin.replace:
+        path: "{{ _roles_dir }}/opencode/defaults/main.yml"
+        regexp: 'opencode_version:\s*"[^"]+"'
+        replace: 'opencode_version: "{{ fetched_opencode_tag }}"'
+
+    - name: Download opencode linux-x64 tarball for sha256 computation
+      ansible.builtin.get_url:
+        url: "https://github.com/anomalyco/opencode/releases/download/{{ fetched_opencode_tag }}/opencode-linux-x64.tar.gz"
+        dest: "/tmp/opencode-{{ fetched_opencode_tag }}-linux-x64.tar.gz"
+        mode: '0644'
+
+    - name: Compute sha256 of opencode linux-x64 tarball
+      ansible.builtin.stat:
+        path: "/tmp/opencode-{{ fetched_opencode_tag }}-linux-x64.tar.gz"
+        checksum_algorithm: sha256
+        get_checksum: true
+      register: _opencode_amd64_stat
+
+    - name: Update opencode_sha256_amd64 in opencode role defaults
+      ansible.builtin.replace:
+        path: "{{ _roles_dir }}/opencode/defaults/main.yml"
+        regexp: 'opencode_sha256_amd64:\s*"[^"]+"'
+        replace: 'opencode_sha256_amd64: "{{ _opencode_amd64_stat.stat.checksum }}"'
+
+    - name: Download opencode linux-arm64 tarball for sha256 computation
+      ansible.builtin.get_url:
+        url: "https://github.com/anomalyco/opencode/releases/download/{{ fetched_opencode_tag }}/opencode-linux-arm64.tar.gz"
+        dest: "/tmp/opencode-{{ fetched_opencode_tag }}-linux-arm64.tar.gz"
+        mode: '0644'
+
+    - name: Compute sha256 of opencode linux-arm64 tarball
+      ansible.builtin.stat:
+        path: "/tmp/opencode-{{ fetched_opencode_tag }}-linux-arm64.tar.gz"
+        checksum_algorithm: sha256
+        get_checksum: true
+      register: _opencode_arm64_stat
+
+    - name: Update opencode_sha256_arm64 in opencode role defaults
+      ansible.builtin.replace:
+        path: "{{ _roles_dir }}/opencode/defaults/main.yml"
+        regexp: 'opencode_sha256_arm64:\s*"[^"]+"'
+        replace: 'opencode_sha256_arm64: "{{ _opencode_arm64_stat.stat.checksum }}"'

--- a/playbooks/update-versions/query-versions.yml
+++ b/playbooks/update-versions/query-versions.yml
@@ -37,6 +37,11 @@
         src: "{{ _roles_dir }}/dolt_sql_server/defaults/main.yml"
       register: _dolt_defaults_raw
 
+    - name: Read opencode role defaults
+      ansible.builtin.slurp:
+        src: "{{ _roles_dir }}/opencode/defaults/main.yml"
+      register: _opencode_defaults_raw
+
     - name: Extract current pinned values from role defaults
       vars:
         _java_id_match: >-
@@ -65,6 +70,10 @@
         current_dolt_version: >-
           {{ _dolt_defaults_raw.content | b64decode
              | regex_search('dolt_version:\s*"([^"]+)"', '\1')
+             | default([], true) | first }}
+        current_opencode_version: >-
+          {{ _opencode_defaults_raw.content | b64decode
+             | regex_search('opencode_version:\s*"([^"]+)"', '\1')
              | default([], true) | first }}
 
     # --- Fetch upstream versions ---
@@ -105,6 +114,15 @@
     - name: Save Dolt fetched tag
       ansible.builtin.set_fact:
         fetched_dolt_tag: "{{ fetched_github_tag }}"
+
+    - name: Fetch OpenCode upstream version
+      ansible.builtin.include_tasks: tasks/fetch-github-release.yml
+      vars:
+        github_repo: "anomalyco/opencode"
+
+    - name: Save OpenCode fetched tag
+      ansible.builtin.set_fact:
+        fetched_opencode_tag: "{{ fetched_github_tag }}"
 
     # --- Compare and report ---
     - name: Report Flutter SDK version status
@@ -155,6 +173,14 @@
           upstream={{ fetched_dolt_tag }},
           status={{ 'UP TO DATE' if current_dolt_version == fetched_dolt_tag else 'STALE' }}
 
+    - name: Report OpenCode version status
+      ansible.builtin.debug:
+        msg: >-
+          OpenCode:
+          current={{ current_opencode_version }},
+          upstream={{ fetched_opencode_tag }},
+          status={{ 'UP TO DATE' if current_opencode_version == fetched_opencode_tag else 'STALE' }}
+
     - name: Fail if any version pins are stale
       ansible.builtin.fail:
         msg: >-
@@ -165,4 +191,5 @@
         current_nerd_font_version != fetched_font_tag or
         current_java_identifier != fetched_java_identifier or
         current_android_build != fetched_android_build or
-        current_dolt_version != fetched_dolt_tag
+        current_dolt_version != fetched_dolt_tag or
+        current_opencode_version != fetched_opencode_tag

--- a/roles/opencode/DESIGN.md
+++ b/roles/opencode/DESIGN.md
@@ -1,0 +1,57 @@
+<!-- SPDX-License-Identifier: MIT-0 -->
+# opencode — Design
+
+Non-obvious decisions for the `opencode` role.
+
+## Integrity Model
+
+OpenCode does not publish an upstream checksum file for its CLI tarballs.
+The two SHA-256 values in `defaults/main.yml` are computed locally on first
+pin and re-computed automatically by
+`playbooks/update-versions/perform-updates.yml` on every version bump.
+
+HTTPS to `github.com` plus a locally pinned SHA-256 is the integrity chain.
+The `get_url` task supplies the per-architecture pin in its `checksum:`
+parameter, so a tampered or corrupted tarball fails the checksum gate
+before extraction and the binary is never written.
+
+## Why Two Separate Per-Architecture Pins
+
+The role supports both `x86_64` (mapped to upstream's `x64` tarball name) and
+`aarch64` (mapped to `arm64`). A single combined "checksum file" pin would
+require either:
+
+- downloading a non-existent upstream manifest, or
+- running both architectures' downloads to derive a single composite hash.
+
+Pinning each architecture's tarball SHA-256 directly avoids that and keeps
+the integrity check local to the one tarball that is actually fetched.
+
+## Idempotency
+
+The role considers the install complete when the binary at
+`opencode_install_path` reports a `--version` string containing the pinned
+version (after stripping the leading `v`). The expensive steps —
+download, extract, copy — are guarded by a single `_opencode_needs_install`
+fact derived from that check, so a re-run on an already-pinned host is a
+no-op. Molecule's `idempotence` phase enforces this.
+
+## Version-Update Integration
+
+The role registers with the project-wide version-update mechanism:
+
+- `query-versions.yml` reads the pinned tag from `defaults/main.yml`,
+  fetches the latest GitHub release tag, and reports STALE if the two
+  differ.
+- `perform-updates.yml` writes the new tag and re-downloads both the
+  `linux-x64` and `linux-arm64` tarballs to recompute their SHA-256 values,
+  then writes both pins back into `defaults/main.yml`. The three values are
+  always updated together — partial bumps are not possible.
+
+## Why Not a System Package
+
+OpenCode does not ship Debian/RPM packages for Linux. The release artefact
+is a static binary tarball published per GitHub release. Wrapping it in a
+local `.deb` would add packaging complexity without changing the integrity
+story (still no upstream signing). A direct tarball install with a local
+SHA-256 pin is the minimum viable trusted install.

--- a/roles/opencode/README.md
+++ b/roles/opencode/README.md
@@ -1,0 +1,50 @@
+<!-- SPDX-License-Identifier: MIT-0 -->
+# opencode
+
+Ansible role that installs the [OpenCode](https://opencode.ai) AI coding agent
+CLI as a system-wide binary at `/usr/local/bin/opencode` on Linux.
+
+See [DESIGN.md](DESIGN.md) for non-obvious decisions and the integrity model.
+
+## Boundary
+
+The role installs the `opencode` binary only. It does not configure LLM
+providers, manage per-user shell PATH (`/usr/local/bin` is already on every
+user's `PATH`), or initialise `AGENTS.md` for any project. Those are
+session-level operations outside this role's scope.
+
+## Requirements
+
+- Ansible 2.19+
+- Linux x86_64 (`x64`) or aarch64 (`arm64`)
+- Internet access to `github.com` from the target host
+
+## Role Variables
+
+All variables have safe defaults. None are required from the caller.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `opencode_version` | `"v1.17.10"` | Pinned OpenCode release tag (`v`-prefixed). |
+| `opencode_sha256_amd64` | *(see defaults)* | SHA-256 of `opencode-linux-x64.tar.gz` for `opencode_version`. |
+| `opencode_sha256_arm64` | *(see defaults)* | SHA-256 of `opencode-linux-arm64.tar.gz` for `opencode_version`. |
+| `opencode_install_path` | `/usr/local/bin/opencode` | Path where the binary is installed. |
+
+The three pinned values (version + both checksums) are updated together by
+`playbooks/update-versions/perform-updates.yml`.
+
+## Dependencies
+
+None. See `meta/main.yml`.
+
+## Example Playbook
+
+```yaml
+- hosts: developers
+  roles:
+    - role: opencode
+```
+
+## License
+
+MIT-0

--- a/roles/opencode/defaults/main.yml
+++ b/roles/opencode/defaults/main.yml
@@ -1,0 +1,19 @@
+#SPDX-License-Identifier: MIT-0
+---
+# Pinned OpenCode CLI release tag (`v`-prefixed). See
+# https://github.com/anomalyco/opencode/releases for available versions.
+opencode_version: "v1.17.10"
+
+# SHA-256 checksums for the linux release tarballs (x64 and arm64).
+# All three values (version + both checksums) must be updated together.
+#
+# Compute (download to file first — pipe-only sha256sum can truncate and give
+# the wrong hash):
+#   curl -sL https://github.com/anomalyco/opencode/releases/download/<version>/opencode-linux-<arch>.tar.gz -o /tmp/opencode.tar.gz
+#   sha256sum /tmp/opencode.tar.gz
+#
+# Updated automatically by playbooks/update-versions/perform-updates.yml.
+opencode_sha256_amd64: "ac24ff27647b57c44e4b0d00ffe4d9e9db32f148b6886b39a83555604fb382cd"
+opencode_sha256_arm64: "cfd8eac5a40096b9209db23f3a336db1e956d5eea68b0f183de3f491f0d874f5"
+
+opencode_install_path: /usr/local/bin/opencode

--- a/roles/opencode/meta/main.yml
+++ b/roles/opencode/meta/main.yml
@@ -1,0 +1,19 @@
+#SPDX-License-Identifier: MIT-0
+---
+galaxy_info:
+  author: Stefan Boos
+  namespace: wonderbird
+  role_name: opencode
+  description: Install the OpenCode AI coding agent CLI on Linux
+  company: n.a.
+  issue_tracker_url: https://github.com/wonderbird/ansible-all-my-things/issues
+  license: MIT-0
+  min_ansible_version: 2.19
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags: []
+
+dependencies: []

--- a/roles/opencode/molecule/default/Dockerfile
+++ b/roles/opencode/molecule/default/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker.io/library/ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends \
+       python3 sudo ca-certificates

--- a/roles/opencode/molecule/default/converge.yml
+++ b/roles/opencode/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: opencode

--- a/roles/opencode/molecule/default/molecule.yml
+++ b/roles/opencode/molecule/default/molecule.yml
@@ -1,0 +1,28 @@
+#SPDX-License-Identifier: MIT-0
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: molecule_opencode_instance
+    pre_build_image: false
+    dockerfile: Dockerfile
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
+    ANSIBLE_PODMAN_MOUNT_DETECTION: "false"
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/roles/opencode/molecule/default/verify.yml
+++ b/roles/opencode/molecule/default/verify.yml
@@ -1,0 +1,38 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Verify
+  hosts: all
+  become: true
+  tasks:
+    - name: Load role defaults for version reference
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/../../defaults/main.yml"
+
+    - name: Stat installed OpenCode binary
+      ansible.builtin.stat:
+        path: /usr/local/bin/opencode
+      register: _verify_opencode_stat
+
+    - name: Assert OpenCode binary exists and is executable
+      ansible.builtin.assert:
+        that:
+          - _verify_opencode_stat.stat.exists
+          - _verify_opencode_stat.stat.executable
+        fail_msg: "/usr/local/bin/opencode missing or not executable"
+        success_msg: "/usr/local/bin/opencode present and executable"
+
+    - name: Get installed OpenCode version
+      ansible.builtin.command:
+        cmd: /usr/local/bin/opencode --version
+      register: _verify_opencode_version
+      changed_when: false
+
+    - name: Assert OpenCode version matches pinned version
+      ansible.builtin.assert:
+        that:
+          - (opencode_version | regex_replace('^v', '')) in _verify_opencode_version.stdout
+        fail_msg: >-
+          Expected OpenCode version {{ opencode_version | regex_replace('^v', '') }}
+          but got: {{ _verify_opencode_version.stdout }}
+        success_msg: >-
+          OpenCode version {{ _verify_opencode_version.stdout }} matches pin

--- a/roles/opencode/tasks/main.yml
+++ b/roles/opencode/tasks/main.yml
@@ -1,0 +1,77 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Validate required variables
+  ansible.builtin.assert:
+    that:
+      - opencode_version | length > 0
+      - opencode_version is match('^v[0-9]+\.[0-9]+\.[0-9]+')
+      - opencode_sha256_amd64 | length == 64
+      - opencode_sha256_arm64 | length == 64
+    fail_msg: >-
+      Variable validation failed: opencode_version must be a non-empty
+      `v`-prefixed semver tag (e.g. v1.17.10); opencode_sha256_amd64 and
+      opencode_sha256_arm64 must each be a 64-character SHA-256 hex digest.
+
+- name: Verify supported processor architecture
+  ansible.builtin.assert:
+    that:
+      - ansible_facts['architecture'] in ['x86_64', 'aarch64']
+    fail_msg: >-
+      Unsupported processor architecture: {{ ansible_facts['architecture'] }}.
+      Supported architectures are: x86_64, aarch64.
+
+- name: Set OpenCode target architecture
+  ansible.builtin.set_fact:
+    _opencode_arch: "{{ 'x64' if ansible_facts['architecture'] == 'x86_64' else 'arm64' }}"
+
+- name: Check if OpenCode binary is installed
+  ansible.builtin.stat:
+    path: "{{ opencode_install_path }}"
+  register: _opencode_binary_stat
+
+- name: Get installed OpenCode version
+  ansible.builtin.command:
+    cmd: "{{ opencode_install_path }} --version"
+  register: _opencode_installed_version
+  changed_when: false
+  when: _opencode_binary_stat.stat.exists
+
+- name: Determine if OpenCode installation is required
+  ansible.builtin.set_fact:
+    _opencode_needs_install: >-
+      {{ not _opencode_binary_stat.stat.exists or
+         (opencode_version | regex_replace('^v', '')) not in
+         (_opencode_installed_version.stdout | default('')) }}
+
+- name: Download OpenCode release tarball
+  ansible.builtin.get_url:
+    url: >-
+      https://github.com/anomalyco/opencode/releases/download/{{ opencode_version }}/opencode-linux-{{ _opencode_arch }}.tar.gz
+    dest: "/tmp/opencode-{{ opencode_version }}-linux-{{ _opencode_arch }}.tar.gz"
+    mode: '0644'
+    checksum: "sha256:{{ opencode_sha256_amd64 if _opencode_arch == 'x64' else opencode_sha256_arm64 }}"
+  when: _opencode_needs_install
+
+- name: Create staging directory for OpenCode extraction
+  ansible.builtin.file:
+    path: "/tmp/opencode-{{ opencode_version }}-linux-{{ _opencode_arch }}"
+    state: directory
+    mode: '0755'
+  when: _opencode_needs_install
+
+- name: Extract OpenCode release tarball
+  ansible.builtin.unarchive:
+    src: "/tmp/opencode-{{ opencode_version }}-linux-{{ _opencode_arch }}.tar.gz"
+    dest: "/tmp/opencode-{{ opencode_version }}-linux-{{ _opencode_arch }}"
+    remote_src: true
+  when: _opencode_needs_install
+
+- name: Install OpenCode binary
+  ansible.builtin.copy:
+    src: "/tmp/opencode-{{ opencode_version }}-linux-{{ _opencode_arch }}/opencode"
+    dest: "{{ opencode_install_path }}"
+    remote_src: true
+    mode: '0755'
+    owner: root
+    group: root
+  when: _opencode_needs_install


### PR DESCRIPTION
## Summary

Bundle of three independent change sets accumulated on the fork since the last sync to upstream. Grouped into A/B/C for review; files touched do not overlap across groups.

| Group | Commits | Topic |
|---|---|---|
| A | 198bd0c, e337ab6 | Install OpenCode AI coding agent CLI via new role |
| B | ce58bae | Record Phase 5b / Phase 6 readiness in roadmap |
| C | a862408, 6beccac, 7ba0259, 4148773 | Extract backup/restore into dedicated guide, fix resulting bugs |

---

## Group A — OpenCode role

Adds Ansible role to install the [OpenCode](https://opencode.ai) AI coding agent CLI as a system-wide binary at `/usr/local/bin/opencode` on Linux (x86_64 and aarch64). Wires the role into the project-wide version-update mechanism.

**Boundary**: installs the binary only. Provider configuration, per-user PATH, and `AGENTS.md` initialisation are session-level concerns outside the role.

**Integrity model**: OpenCode does not publish an upstream checksum file. HTTPS plus a locally pinned per-architecture SHA-256, checked by `get_url` before extraction, is the integrity chain. A tampered or corrupted tarball fails the checksum gate before the binary is written. See `roles/opencode/DESIGN.md` for full rationale.

**Version-update wiring**:
- `query-versions.yml`: reads pinned tag, fetches latest GitHub release from `anomalyco/opencode`, reports STALE if they differ, includes opencode in the fail-on-stale gate.
- `perform-updates.yml`: writes the new tag and recomputes SHA-256 of both `linux-x64` and `linux-arm64` tarballs, then writes both pins back to `defaults/main.yml`. Partial bumps not possible.

**Verified**: `molecule test` on aarch64 (destroy → syntax → create → converge → idempotence → verify → destroy) all pass. `verify.yml` asserts binary present, executable, `--version` reports `v1.17.10`.

---

## Group B — Roadmap

Single doc update to `docs/feature-requests/feat.create-destroy-vm/roadmap.md` recording that Phase 5b (windows profile, aws-only) shipped and Phase 6 is now READY TO START. Standalone; no code changes.

---

## Group C — Backup/restore refactor

Four tightly coupled commits — please review as one logical change set:

1. `6beccac` extracts backup/restore instructions from `work-with-vm.md` and `create-vm.md` into a dedicated `docs/user-manual/backup-restore.md`, removing duplication.
2. `4148773` fixes the cryptic failure that surfaced once the deduplicated playbooks were run without `-e backup_from_host=<host>`.
3. `7ba0259` removes a now-duplicate `backup_from_host` comment from `inventories/group_vars/all/vars.yml`.
4. `a862408` corrects 3 defects found by review of the new `backup-restore.md`: broken relative links (`../` → `../../`), a reference to a nonexistent `/configure.yml`, and a stale claim that Cursor is backed up.

Files touched: `backup.yml`, `inventories/group_vars/all/vars.yml`, `README.md`, `docs/user-manual/{backup-restore.md, create-vm.md, work-with-vm.md}`.

---

## Verification

- Group A: molecule test passes all phases on aarch64 host (this PR was originally #40 on the fork, where it was reviewed and merged).
- Groups B and C: doc-only and playbooks changes; no automated test added in this bundle. Backups should be verified manually against `backup-restore.md` before next backup run.

Assisted-by: OpenCode