### PR TITLE
feat: bd-guard hook blocks runaway beads command

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -54,6 +54,4 @@
 # - linear.api_key  → use LINEAR_API_KEY env var instead
 # - github.token    → use GITHUB_TOKEN env var instead
 
-export.git-add: false
-
-sync.remote: "https://github.com/eudicy/ansible-all-my-things.git"
+sync.remote: "git+https://github.com/eudicy/ansible-all-my-things.git"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
         "matcher": ""
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command'); echo \"$cmd\" | grep -qE '(^|[[:space:]])(rtk[[:space:]]+)?git[[:space:]]' && exit 0; echo \"$cmd\" | grep -qF 'bd list --all' && { echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: bd list --all causes unbounded 5.6GB output loop in this repo (issue 1fg7). Use .beads/issues.jsonl with grep/jq for bulk reads, or scoped commands: bd ready, bd list --status <s>, bd list --priority <p>, bd show <id>.\"}'; exit 2; }"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command'); echo \"$cmd\" | grep -qE '(^|[[:space:]])(rtk[[:space:]]+)?git[[:space:]]' && exit 0; echo \"$cmd\" | grep -qF 'bd list --all' && { echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: bd list --all causes unbounded 5.6GB output loop in this repo (issue 1fg7). Use .beads/issues.jsonl with grep/jq for bulk reads, or scoped commands: bd ready, bd list --status <s>, bd list --priority <p>, bd show <id>.\"}'; exit 2; }"
+            "command": "cmd=$(jq -r '.tool_input.command'); echo \"$cmd\" | grep -qE '(^|[[:space:]])(rtk[[:space:]]+)?git[[:space:]]' && exit 0; echo \"$cmd\" | grep -qE '(^|[[:space:]])(bd)[[:space:]]+list[[:space:]]+--all' && { echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: bd list --all causes unbounded 5.6GB output loop in this repo (issue 1fg7). Use .beads/issues.jsonl with grep/jq for bulk reads, or scoped commands: bd ready, bd list --status <s>, bd list --priority <p>, bd show <id>.\"}'; exit 2; }"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command'); echo \"$cmd\" | grep -qE '(^|[[:space:]])(rtk[[:space:]]+)?git[[:space:]]' && exit 0; echo \"$cmd\" | grep -qE '(^|[[:space:]])(bd)[[:space:]]+list[[:space:]]+--all' && { echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: bd list --all causes unbounded 5.6GB output loop in this repo (issue 1fg7). Use .beads/issues.jsonl with grep/jq for bulk reads, or scoped commands: bd ready, bd list --status <s>, bd list --priority <p>, bd show <id>.\"}'; exit 2; }"
+            "command": "cmd=$(jq -r '.tool_input.command'); echo \"$cmd\" | grep -qE '(^|[[:space:]])(rtk[[:space:]]+)?git[[:space:]]' && exit 0; echo \"$cmd\" | grep -qE '(^|[[:space:]])(bd)[[:space:]]+list[[:space:]]+--all' && { echo '{\"decision\":\"block\",\"reason\":\"BLOCKED: bd list --all causes unbounded 5.6GB output loop in this repo (issue 1fg7). Use .beads/issues.jsonl with grep/jq for bulk reads, or scoped commands: bd ready, bd list --status <s>, bd list --priority <p>, bd show <id>.\"}'; exit 2; }; exit 0"
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-<!-- markdownlint-disable MD013 MD031 MD032 -->
+<!-- markdownlint-disable MD013 MD022 MD025 MD031 MD032 MD034 -->
 <!-- rtk-instructions v2 -->
 # RTK (Rust Token Killer) - Token-Optimized Commands
 
@@ -160,6 +160,12 @@ bd close <id>         # Complete work
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
 
+**NEVER run `bd list --all`** — at ~350 issues it enters an unbounded output loop (5.6 GB,
+100% CPU, SIGKILL, nearly fills the 17 GB agent disk). For bulk reads, query
+`.beads/issues.jsonl` directly with `grep`/`jq`. For live queries use only scoped
+commands: `bd ready`, `bd list --status <s>`, `bd list --priority <p>`, `bd show <id>`.
+If unavoidable, bound it: `timeout 20 bd list --all`. (Bug tracked: 1fg7)
+
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 
 ## Session Completion
@@ -188,7 +194,7 @@ bd close <id>         # Complete work
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
 <!-- END BEADS INTEGRATION -->
-<!-- markdownlint-enable MD013 MD031 MD032 -->
+<!-- markdownlint-enable MD013 MD022 MD025 MD031 MD032 MD034 -->
 
 ## Beads: Data Safety and Workflow Rules
 

--- a/roles/claude_code/DESIGN.md
+++ b/roles/claude_code/DESIGN.md
@@ -35,3 +35,26 @@ deploying a template. The file may contain user-managed keys that a template
 would overwrite. The jq script detects whether the target state already exists
 and prints `NO_CHANGE` or `CHANGED`, which `changed_when` uses to report
 accurately.
+
+## settings.json: bd-guard hook via jq --arg
+
+The bd-guard `PreToolUse` hook blocks `bd list --all`, which enters an unbounded
+output loop at ~350 issues in this repo (5.6 GB output, 100% CPU, SIGKILL).
+
+The hook command contains embedded single quotes (shell guards, jq calls, the
+JSON error payload), making it impossible to embed literally inside a jq
+expression that is itself single-quoted in bash. `configure.yml` therefore
+assigns the command string via a quoted heredoc (`<<'HOOKEOF'`) to a
+`BD_HOOK_CMD` variable and passes it to jq as `--arg bdcmd "$BD_HOOK_CMD"`.
+The jq expression references `$bdcmd` without quoting issues.
+
+The idempotency check uses `.command | contains("bd list --all")` rather than an
+exact string match so that minor future rewrites of the hook command do not cause
+duplicate entries.
+
+The hook uses `grep -qE '(^|[[:space:]])(bd)[[:space:]]+list[[:space:]]+--all'`
+so it only fires when `bd` appears at the start of the command or after
+whitespace. This avoids false positives when the literal string
+`bd list --all` appears inside a grep argument (`grep -qF 'bd list --all'`)
+or a jq expression (`contains("bd list --all")`), where `bd` is preceded
+by a quote character, not whitespace.

--- a/roles/claude_code/molecule/default/verify.yml
+++ b/roles/claude_code/molecule/default/verify.yml
@@ -160,6 +160,21 @@
         fail_msg: "rtk hook claude not found in settings.json PreToolUse hooks"
         success_msg: "rtk hook claude configured in settings.json"
 
+    - name: Check bd-guard hook is configured in settings.json
+      ansible.builtin.shell: >
+        jq -e '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[] |
+        select(.command | contains("bd list --all"))' /home/testuser/.claude/settings.json
+      changed_when: false
+      failed_when: false
+      register: bd_guard_hook_check
+
+    - name: Assert bd-guard PreToolUse hook is present in settings.json
+      ansible.builtin.assert:
+        that:
+          - bd_guard_hook_check.rc == 0
+        fail_msg: "bd list --all guard hook not found in settings.json PreToolUse hooks"
+        success_msg: "bd list --all guard hook configured in settings.json"
+
     - name: Run rtk init -g as testuser
       ansible.builtin.command:
         cmd: rtk init -g

--- a/roles/claude_code/tasks/configure.yml
+++ b/roles/claude_code/tasks/configure.yml
@@ -18,11 +18,18 @@
     else
       CURRENT='{}'
     fi
-    MERGED=$(printf '%s' "$CURRENT" | jq '
+    BD_HOOK_CMD=$(cat <<'HOOKEOF'
+    cmd=$(jq -r '.tool_input.command'); echo "$cmd" | grep -qE '(^|[[:space:]])(rtk[[:space:]]+)?git[[:space:]]' && exit 0; echo "$cmd" | grep -qE '(^|[[:space:]])(bd)[[:space:]]+list[[:space:]]+--all' && { echo '{"decision":"block","reason":"BLOCKED: bd list --all causes unbounded 5.6GB output loop in this repo (issue 1fg7). Use .beads/issues.jsonl with grep/jq for bulk reads, or scoped commands: bd ready, bd list --status <s>, bd list --priority <p>, bd show <id>."}'; exit 2; }
+    HOOKEOF
+    )
+    MERGED=$(printf '%s' "$CURRENT" | jq --arg bdcmd "$BD_HOOK_CMD" '
       .env = (.env // {} | . + {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1","CLAUDE_CODE_SPAWN_BACKEND":"tmux"})
       | .teammateMode = "tmux"
       | if (.hooks.PreToolUse // [] | map(select((.hooks // [] | map(select(.command == "rtk hook claude")) | length > 0))) | length) == 0
         then .hooks.PreToolUse = ((.hooks.PreToolUse // []) + [{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook claude"}]}])
+        else . end
+      | if (.hooks.PreToolUse // [] | map(select((.hooks // [] | map(select(.command | contains("bd list --all"))) | length > 0))) | length) == 0
+        then .hooks.PreToolUse = ((.hooks.PreToolUse // []) + [{"matcher":"Bash","hooks":[{"type":"command","command":$bdcmd}]}])
         else . end
     ')
     CURRENT_NORMALIZED=$(printf '%s' "$CURRENT" | jq '.')

--- a/roles/claude_code/tasks/configure.yml
+++ b/roles/claude_code/tasks/configure.yml
@@ -19,7 +19,7 @@
       CURRENT='{}'
     fi
     BD_HOOK_CMD=$(cat <<'HOOKEOF'
-    cmd=$(jq -r '.tool_input.command'); echo "$cmd" | grep -qE '(^|[[:space:]])(rtk[[:space:]]+)?git[[:space:]]' && exit 0; echo "$cmd" | grep -qE '(^|[[:space:]])(bd)[[:space:]]+list[[:space:]]+--all' && { echo '{"decision":"block","reason":"BLOCKED: bd list --all causes unbounded 5.6GB output loop in this repo (issue 1fg7). Use .beads/issues.jsonl with grep/jq for bulk reads, or scoped commands: bd ready, bd list --status <s>, bd list --priority <p>, bd show <id>."}'; exit 2; }
+    cmd=$(jq -r '.tool_input.command'); echo "$cmd" | grep -qE '(^|[[:space:]])(rtk[[:space:]]+)?git[[:space:]]' && exit 0; echo "$cmd" | grep -qE '(^|[[:space:]])(bd)[[:space:]]+list[[:space:]]+--all' && { echo '{"decision":"block","reason":"BLOCKED: bd list --all causes unbounded 5.6GB output loop in this repo (issue 1fg7). Use .beads/issues.jsonl with grep/jq for bulk reads, or scoped commands: bd ready, bd list --status <s>, bd list --priority <p>, bd show <id>."}'; exit 2; }; exit 0
     HOOKEOF
     )
     MERGED=$(printf '%s' "$CURRENT" | jq --arg bdcmd "$BD_HOOK_CMD" '


### PR DESCRIPTION
## Summary

- Adds `PreToolUse` Bash hook to `.claude/settings.json` blocking the runaway beads command that causes an unbounded 5.6 GB output loop at ~350 issues (100% CPU, SIGKILL)
- Extends `roles/claude_code/tasks/configure.yml` to merge the hook idempotently via `jq --arg`, so it survives VM deletion and restore
- Adds Molecule `verify.yml` assertion and `DESIGN.md` rationale
- Documents the prohibition in `AGENTS.md` with safe alternatives (`bd ready`, `bd list --status <s>`, `bd list --priority <p>`, `bd show <id>`)

## Test plan

- [ ] Run `molecule test` on `claude_code` role — verify.yml bd-guard assert passes
- [ ] Confirm hook fires on the blocked command in a Claude Code session
- [ ] Confirm hook is silent for any non-matching bash command (no hook error warning)
- [ ] Re-run Ansible with hook already present — task reports `NO_CHANGE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
