### PR TITLE
fix: git binary was missing before TPM clone in tmux role

### DIFF
--- a/roles/tmux/tasks/install-plugins.yml
+++ b/roles/tmux/tasks/install-plugins.yml
@@ -1,5 +1,11 @@
 #SPDX-License-Identifier: MIT-0
 ---
+- name: Install git
+  ansible.builtin.apt:
+    name: git
+    state: present
+    update_cache: false
+
 - name: Clone TPM for each user
   ansible.builtin.git:
     repo: "{{ tmux_plugin_tpm_repo }}"


### PR DESCRIPTION
## Summary

- The tmux role clones TPM and other plugins via `ansible.builtin.git` but never installed `git` first
- On fresh Docker VMs provisioned with `create-vm.yml`, `git` is absent, causing the clone tasks to fail with `Failed to find required executable "git"`
- Added an `apt` install task for `git` at the top of `install-plugins.yml`

## Test plan

- [x] `molecule test` passes (converge, idempotence, verify all green)
- [x] Idempotence check confirms `Install git` reports `ok` (not `changed`) on second run

Refs: ansible-all-my-things-efgf

🤖 Generated with [Claude Code](https://claude.com/claude-code)