### PR TITLE
fix: ansible_env and ansible_architecture caused deprecation warnings

### DIFF
--- a/playbooks/tasks/destroy/tart.yml
+++ b/playbooks/tasks/destroy/tart.yml
@@ -44,7 +44,7 @@
 
 - name: Check if VM exists in tart
   ansible.builtin.stat:
-    path: "{{ ansible_env.HOME }}/.tart/vms/{{ hostname }}"
+    path: "{{ ansible_facts['env']['HOME'] }}/.tart/vms/{{ hostname }}"
   register: tart_vm_stat
 
 - name: Warn if VM is absent from tart (stale inventory entry)

--- a/roles/android_studio/tasks/main.yml
+++ b/roles/android_studio/tasks/main.yml
@@ -105,7 +105,7 @@
     sdk_root: "/home/{{ item }}/Android/Sdk"
   environment:
     JAVA_HOME: "/home/{{ item }}/.sdkman/candidates/java/{{ java_sdkman_identifier }}"
-    PATH: "/home/{{ item }}/Android/Sdk/cmdline-tools/latest/bin:{{ ansible_env.PATH }}"
+    PATH: "/home/{{ item }}/Android/Sdk/cmdline-tools/latest/bin:{{ ansible_facts['env']['PATH'] }}"
   become_user: "{{ item }}"
   loop: "{{ desktop_user_names }}"
   loop_control:

--- a/roles/claude_code/tasks/install-addons.yml
+++ b/roles/claude_code/tasks/install-addons.yml
@@ -154,7 +154,7 @@
   become: true
   become_user: "{{ item }}"
   environment:
-    PATH: "/home/{{ item }}/.local/bin:{{ ansible_env.PATH }}"
+    PATH: "/home/{{ item }}/.local/bin:{{ ansible_facts['env']['PATH'] }}"
   loop: "{{ desktop_user_names }}"
   failed_when: false
   changed_when: false
@@ -166,7 +166,7 @@
   become: true
   become_user: "{{ item }}"
   environment:
-    PATH: "/home/{{ item }}/.local/bin:{{ ansible_env.PATH }}"
+    PATH: "/home/{{ item }}/.local/bin:{{ ansible_facts['env']['PATH'] }}"
   loop: "{{ desktop_user_names }}"
   failed_when: false
   changed_when: false
@@ -178,7 +178,7 @@
   become: true
   become_user: "{{ item }}"
   environment:
-    PATH: "/home/{{ item }}/.local/bin:{{ ansible_env.PATH }}"
+    PATH: "/home/{{ item }}/.local/bin:{{ ansible_facts['env']['PATH'] }}"
   loop: "{{ desktop_user_names }}"
   when: "'  ❯ omc' not in (plugin_marketplace_check.results | selectattr('item', 'equalto', item) | first).stdout_lines"
 
@@ -188,7 +188,7 @@
   become: true
   become_user: "{{ item }}"
   environment:
-    PATH: "/home/{{ item }}/.local/bin:{{ ansible_env.PATH }}"
+    PATH: "/home/{{ item }}/.local/bin:{{ ansible_facts['env']['PATH'] }}"
   loop: "{{ desktop_user_names }}"
   when: "'  ❯ oh-my-claudecode@omc' not in (plugin_list_check.results | selectattr('item', 'equalto', item) | first).stdout_lines"
 
@@ -198,7 +198,7 @@
   become: true
   become_user: "{{ item }}"
   environment:
-    PATH: "/home/{{ item }}/.local/bin:{{ ansible_env.PATH }}"
+    PATH: "/home/{{ item }}/.local/bin:{{ ansible_facts['env']['PATH'] }}"
   loop: "{{ desktop_user_names }}"
   when: "'  ❯ caveman' not in (plugin_marketplace_check.results | selectattr('item', 'equalto', item) | first).stdout_lines"
 
@@ -208,7 +208,7 @@
   become: true
   become_user: "{{ item }}"
   environment:
-    PATH: "/home/{{ item }}/.local/bin:{{ ansible_env.PATH }}"
+    PATH: "/home/{{ item }}/.local/bin:{{ ansible_facts['env']['PATH'] }}"
   loop: "{{ desktop_user_names }}"
   when: "'  ❯ caveman@caveman' not in (plugin_list_check.results | selectattr('item', 'equalto', item) | first).stdout_lines"
 
@@ -218,7 +218,7 @@
   become: true
   become_user: "{{ item }}"
   environment:
-    PATH: "/home/{{ item }}/.local/bin:{{ ansible_env.PATH }}"
+    PATH: "/home/{{ item }}/.local/bin:{{ ansible_facts['env']['PATH'] }}"
   loop: "{{ desktop_user_names }}"
   when: >-
     (plugin_marketplace_check.results
@@ -234,7 +234,7 @@
   become: true
   become_user: "{{ item }}"
   environment:
-    PATH: "/home/{{ item }}/.local/bin:{{ ansible_env.PATH }}"
+    PATH: "/home/{{ item }}/.local/bin:{{ ansible_facts['env']['PATH'] }}"
   loop: "{{ desktop_user_names }}"
   when: >-
     (plugin_list_check.results

--- a/roles/claude_code/tasks/install-claude-code.yml
+++ b/roles/claude_code/tasks/install-claude-code.yml
@@ -3,9 +3,9 @@
 # Only ansible platforms listed in claude_code_platform_map are supported.
 - name: "Verify supported processor architecture"
   assert:
-    that: "ansible_architecture in claude_code_platform_map"
+    that: "ansible_facts['architecture'] in claude_code_platform_map"
     fail_msg: >
-     Unsupported processor architecture: {{ ansible_architecture }}.
+     Unsupported processor architecture: {{ ansible_facts['architecture'] }}.
      Supported architectures are: {{ claude_code_platform_map.keys() | list }}.
 
 # -----
@@ -34,7 +34,7 @@
 
 - name: Extract expected Claude Code checksum from release manifest
   set_fact:
-    claude_code_expected_checksum: "{{ claude_code_manifest.json.platforms[claude_code_platform_map[ansible_architecture]].checksum }}"
+    claude_code_expected_checksum: "{{ claude_code_manifest.json.platforms[claude_code_platform_map[ansible_facts['architecture']]].checksum }}"
 
 # -----
 # Install Claude Code for each desktop user

--- a/roles/cursor_ide/tasks/main.yml
+++ b/roles/cursor_ide/tasks/main.yml
@@ -4,7 +4,7 @@
 # (tested on 2026-01-14)
 - name: Set architecture-specific download URL
   set_fact:
-    cursor_download_url: "{{ cursor_urls[ansible_architecture] | default(cursor_urls['aarch64']) }}"
+    cursor_download_url: "{{ cursor_urls[ansible_facts['architecture']] | default(cursor_urls['aarch64']) }}"
   vars:
     cursor_urls:
       x86_64:  'https://api2.cursor.sh/updates/download/golden/linux-x64-deb/cursor/'

--- a/roles/tmux/tasks/install-gitmux.yml
+++ b/roles/tmux/tasks/install-gitmux.yml
@@ -2,9 +2,9 @@
 ---
 - name: Verify supported processor architecture
   ansible.builtin.assert:
-    that: "ansible_architecture in tmux_gitmux_arch_map"
+    that: "ansible_facts['architecture'] in tmux_gitmux_arch_map"
     fail_msg: >
-      Unsupported processor architecture: {{ ansible_architecture }}.
+      Unsupported processor architecture: {{ ansible_facts['architecture'] }}.
       Supported architectures are: {{ tmux_gitmux_arch_map.keys() | list }}.
 
 - name: Check if gitmux is installed
@@ -14,7 +14,7 @@
 
 - name: Set gitmux architecture
   ansible.builtin.set_fact:
-    tmux_gitmux_arch: "{{ tmux_gitmux_arch_map[ansible_architecture] }}"
+    tmux_gitmux_arch: "{{ tmux_gitmux_arch_map[ansible_facts['architecture']] }}"
   when: not tmux_gitmux_binary_stat.stat.exists
 
 - name: Set gitmux archive name


### PR DESCRIPTION
## Summary

- Replaces all 17 occurrences of top-level injected fact references (`ansible_env`, `ansible_architecture`) with the stable `ansible_facts['fact_name']` dict syntax across 6 files
- Eliminates `INJECT_FACTS_AS_VARS` deprecation warnings emitted by ansible-core 2.24+ in roles `claude_code`, `tmux`, `cursor_ide`, `android_studio` and the `destroy/tart.yml` task file

## Root cause

`inject_facts_as_vars=True` (Ansible default, deprecated for ansible-core 2.24) auto-injects gathered facts as top-level `ansible_*` variables. Code that reads `ansible_env.PATH` or `ansible_architecture` directly triggers the deprecation warning. The fix is to use `ansible_facts['env']['PATH']` and `ansible_facts['architecture']` respectively — values are identical, behavior is preserved.

## Files changed

| File | Occurrences |
|---|---|
| `roles/claude_code/tasks/install-addons.yml` | 8× `ansible_env.PATH` |
| `roles/claude_code/tasks/install-claude-code.yml` | 3× `ansible_architecture` |
| `roles/tmux/tasks/install-gitmux.yml` | 3× `ansible_architecture` |
| `roles/cursor_ide/tasks/main.yml` | 1× `ansible_architecture` |
| `roles/android_studio/tasks/main.yml` | 1× `ansible_env.PATH` |
| `playbooks/tasks/destroy/tart.yml` | 1× `ansible_env.HOME` |

## Test plan

- [x] `molecule test` passes for `claude_code` role (covers 11 of 17 occurrences at runtime)
- [x] `molecule test` passes for `tmux` role (covers 3 of 17 occurrences at runtime)
- [x] Grep gate confirms zero legacy references in YAML files: `grep -rn "ansible_env\.\|ansible_architecture\b" roles/ playbooks/ --include="*.yml" | grep -v ansible_facts` returns no output
- [x] No `INJECT_FACTS_AS_VARS` deprecation warnings in molecule output

🤖 Generated with [Claude Code](https://claude.com/claude-code)